### PR TITLE
feat: add route-aware walkthrough rail onboarding

### DIFF
--- a/EfficientAI-Docs/docs/intro.md
+++ b/EfficientAI-Docs/docs/intro.md
@@ -6,46 +6,39 @@ sidebar_position: 1
 
 # Introduction
 
-## What is EfficientAI?
+EfficientAI is a voice AI evaluation platform for testing, measuring, and improving conversational agents before they reach production.
 
-Think of **EfficientAI** as a high-tech training gym for your Voice AI.
+It helps teams run realistic simulations, analyze outcomes with explicit metrics, and iterate quickly on agent behavior, prompts, and voice quality.
 
-Building a Voice AI (like a customer service bot) is hard. You don't want to test it on real customers until you are sure it works perfectly. EfficientAI lets you practice by having **simulated customers** (robots pretending to be people) call your AI and test it out.
+## What the platform does
 
-We help you answer questions like:
-*   "Can my AI understand a thick accent?"
-*   "Does my AI stay calm when the customer is angry?"
-*   "Is my AI fast enough?"
+EfficientAI gives you an end-to-end loop for voice AI quality:
 
-## How does it work?
+1. Configure the **Agent** you want to test.
+2. Configure **Personas** with mapped voices for caller simulation.
+3. Define **Scenarios** that represent conversation goals.
+4. Run tests in the **Agent Playground** or evaluator workflows.
+5. Score calls using enabled **Metrics**.
+6. Improve prompts and re-test to track quality over time.
 
-Imagine you are hiring a new customer support agent. Before letting them answer real calls, you would role-play with them. You might pretend to be an angry customer with a broken product to see how they handle it.
+## Core capabilities
 
-EfficientAI automates this role-play:
+- **Agent testing across call setups**: supports inbound/outbound context and phone/web call mediums.
+- **Prompt management**: maintain an internal test-agent prompt and sync provider prompts from external voice platforms.
+- **Voice bundle composition**: configure STT, LLM, and TTS stacks (or S2S where configured) for test-agent behavior.
+- **Persona voice mapping**: personas are tied to concrete provider and voice identities.
+- **Scenario generation and curation**: generate from agent prompts, derive from call transcripts/call data, or create manually.
+- **Metric-driven evaluation**: enable the exact metrics you want and apply them consistently across runs.
+- **Prompt optimization workflows**: run optimization loops, compare candidates, accept winners, and push selected prompts to providers.
 
-1.  **The Employee (Agent)**: This is your Voice AI that you are building.
-2.  **The Actor (Persona)**: We have a robot caller that pretends to differnt people—like "Bob from Texas" or "Alice from London".
-3.  **The Script (Scenario)**: You give the Actor a secret mission, like "Call and try to return a pair of shoes without a receipt."
-4.  **The Scorecard (Evaluator)**: After the call, we grade your AI. Did it solve the problem? Was it polite? Did it understand what the Actor said?
+## Platform model
 
-## Why use it?
+At a high level:
 
-*   **Save Money**: Don't waste your team's time manually calling your bot 100 times.
-*   **Find Bugs**: Catch problems before your real customers do.
-*   **Improve Quality**: See exactly where your AI is struggling so you can fix it.
+- **Agents** are the systems under test.
+- **Personas** represent simulated callers with specific voice identities.
+- **Scenarios** define goals and test context.
+- **Metrics** evaluate objective completion and voice quality.
+- **Results** provide run-level evidence for iteration decisions.
 
----
-
-## Technical Overview
-
-For developers and engineers, EfficientAI is a comprehensive platform designed to evaluate and improve Voice AI agents. It effectively closes the feedback loop by simulating real-world conversations using AI-driven test agents (Personas) and Scenarios, and then rigorously evaluating the performance using a suite of quantitative and qualitative metrics.
-
-### High-Level Architecture
-
-The platform consists of several core components that work together to automate the testing and evaluation process:
-
-1.  **Voice AI Integration**: Connects to external Voice AI providers (e.g., Retell, Vapi) or manages internal models.
-2.  **Test Agents (Personas)**: Simulated users with specific attributes (accent, gender, background noise) that interact with the Voice AI.
-3.  **Scenarios**: Defined conversation paths and objectives that the Test Agent attempts to follow or achieve.
-4.  **Orchestrator**: Manages the live conversation between the Voice AI and the Test Agent, handling audio streaming, transcription, and response generation.
-5.  **Evaluators**: Post-conversation analysis metrics that assess the Voice AI's performance based on the specific scenario benchmarks.
+This structure keeps testing reproducible while still reflecting real-world voice interactions.

--- a/EfficientAI-Docs/docs/products/agents.md
+++ b/EfficientAI-Docs/docs/products/agents.md
@@ -6,44 +6,76 @@ sidebar_position: 1
 
 # Agents
 
-## What is an Agent?
+An Agent is the voice system you are evaluating in EfficientAI.
 
-In EfficientAI, the **Agent** is simply **Your Voice AI**. It's the robot or system you are building and want to test.
+## Agent paths in practice
 
-Think of it as the "Employee" you are training. You want to see how good this employee is at talking to customers.
+An agent can be configured for one or both execution paths:
 
-## Setting up an Agent
+- **Test Agent path (internal)**: uses an EfficientAI voice bundle to run STT -> LLM -> TTS behavior.
+- **Voice AI Agent path (external)**: links to an external voice provider agent, such as Retell, Vapi, or ElevenLabs.
 
-To test your AI, you need to tell EfficientAI where to find it. You can do this in the "Agents" section of the dashboard.
+If both are configured, you can test both paths from the Agent Playground.
 
-You generally need to tell us:
-*   **Name**: What do you call your bot? (e.g., "Support Bot V1")
-*   **Call Type**: Does your bot take calls (Inbound) or make calls (Outbound)?
-*   **Connection**: How do we talk to it? (Using a phone number, or a direct software header).
-
----
-
-## Technical Details
-
-For developers, an **Agent** represents the system under test (SUT). This is your Voice AI application, whether hosted on an external platform (retell AI, Vapi) or a custom internal solution.
-
-### Configuration
-
-Agents are registered in the system with the following properties:
+## Core configuration
 
 | Property | Type | Description |
 |---|---|---|
-| `name` | String | Name of the agent. |
-| `agent_id` | String | A unique 6-digit identifier used within EfficientAI. |
-| `phone_number` | String | (Optional) The PSTN number to dial if testing via phone network. |
-| `language` | Enum | The primary language the agent is expected to speak (`en`, `es`, etc.). |
-| `call_type` | Enum | `inbound` (Agent receives calls) or `outbound` (Agent places calls). |
-| `call_medium` | Enum | `phone_call` (PSTN) or `web_call` (VoIP/WebRTC). |
+| `name` | String | Human-readable agent name. |
+| `language` | Enum | Primary language context for evaluation. |
+| `call_type` | Enum | `inbound` or `outbound` behavior context. |
+| `call_medium` | Enum | `phone_call` or `web_call`. |
+| `phone_number` | String | Required when `call_medium = phone_call`. |
+| `voice_bundle_id` | UUID | Internal test stack for voice-bundle testing. |
+| `voice_ai_integration_id` | UUID | External provider integration reference. |
+| `voice_ai_agent_id` | String | External provider agent identifier. |
 
-### Integration Types
+## Inbound vs outbound calls
 
-Agents connect to the evaluation platform through one of three mutually exclusive methods:
+Use `call_type` to model the call direction your production agent is designed for:
 
-1.  **Voice Bundle**: A comprehensive stack defining STT, LLM, and TTS providers.
-2.  **AI Provider**: Direct reference to a generic AI provider configuration.
-3.  **External Integration**: For third-party platforms like Retell or Vapi.
+- **Inbound**: user initiates call to the agent.
+- **Outbound**: agent initiates call to the user.
+
+This setting should match your real deployment pattern so evaluation conditions are realistic.
+
+## Prompt management
+
+Agents can carry two prompt surfaces:
+
+- **EfficientAI Test Agent Description (`description`)**  
+  Internal prompt used for test-agent behavior and evaluation context.
+- **Provider Prompt (`provider_prompt`)**  
+  Prompt fetched from the linked external voice provider.
+
+### Provider prompt sync
+
+When an agent is linked to an external provider, EfficientAI can fetch and store the current provider prompt.
+
+Sync can happen:
+
+- automatically on relevant create/update operations, and
+- manually through "Sync Now" in the agent view.
+
+This keeps local review and optimization aligned with what is currently running on the provider.
+
+## Voice bundles
+
+Voice bundles define how internal test-agent conversations are generated.
+
+Supported bundle types:
+
+- **STT + LLM + TTS**
+- **S2S** (speech-to-speech)
+
+For STT + LLM + TTS bundles, model/provider settings are configured per stage, including optional LLM temperature and max token controls.
+
+## External voice integrations
+
+For live external testing, configure:
+
+1. `voice_ai_integration_id`
+2. `voice_ai_agent_id`
+3. `call_medium = web_call` for Agent Playground web calls
+
+This enables real-time provider calls and evaluation flow from provider call data into EfficientAI results.

--- a/EfficientAI-Docs/docs/products/agents.md
+++ b/EfficientAI-Docs/docs/products/agents.md
@@ -13,7 +13,7 @@ An Agent is the voice system you are evaluating in EfficientAI.
 An agent can be configured for one or both execution paths:
 
 - **Test Agent path (internal)**: uses an EfficientAI voice bundle to run STT -> LLM -> TTS behavior.
-- **Voice AI Agent path (external)**: links to an external voice provider agent, such as Retell, Vapi, or ElevenLabs.
+- **Voice AI Agent path (external)**: links to an external voice provider agent, such as Retell, Vapi, or ElevenLabs etc.
 
 If both are configured, you can test both paths from the Agent Playground.
 

--- a/EfficientAI-Docs/docs/products/metrics.md
+++ b/EfficientAI-Docs/docs/products/metrics.md
@@ -6,76 +6,74 @@ sidebar_position: 5
 
 # Metrics
 
-## What are Metrics?
+Metrics are the explicit scoring rules used to evaluate each call.
 
-**Metrics** are the "Grades" or "Scorecards" for your AI.
+## Metric selection is explicit
 
-After a test call finishes, you want to know how well it went. EfficientAI answers this with data.
+Only metrics that are **enabled** for your organization are evaluated.
 
-We give you two types of grades:
-1.  **Quantitative Metrics**: Hard numbers like latency, speaking rate, and voice quality measurements.
-2.  **Qualitative Metrics**: Subjective scores like how human the AI sounds or emotional accuracy.
+This means run scoring always reflects your currently enabled metric set, not a hidden global default.
 
----
+## Metric groups
 
-## Quantitative Metrics
+EfficientAI evaluates three practical metric groups:
 
-These are calculated automatically from the audio and conversation data:
+### 1) LLM-evaluated conversation metrics
 
-| Metric | Description |
-|--------|-------------|
-| **E2E Latency** | End-to-end response time — how fast the AI responds |
-| **Pitch Variance** | Voice pitch variation analysis |
-| **Jitter & Shimmer** | Voice quality fluctuations — stability of the voice |
-| **Speaking Rate (WPM)** | Words per minute — conversation pacing |
-| **Interruption Gap** | Time between speaker turns |
-| **HNR** | Harmonics-to-Noise Ratio — voice clarity measurement |
-| **Turn Taking** | Speaker transition patterns and timing |
-| **Barge-In Interruption** | Detection of when speakers talk over each other |
-| **Silence Duration** | Length and frequency of pauses |
+Examples:
 
-### How They Work
+- Follow Instructions
+- Professionalism
+- Problem Resolution
 
-Quantitative metrics are computed by analyzing:
-- Audio waveforms (for pitch, jitter, shimmer, HNR)
-- Timestamps (for latency, turn taking, gaps)
-- Transcriptions (for speaking rate)
+Method:
 
----
+- Evaluates transcript and context against metric definitions.
 
-## Qualitative Metrics
+### 2) Acoustic metrics (signal-based)
 
-These are evaluated using LLM analysis of the conversation:
+Examples:
 
-| Metric | Description |
-|--------|-------------|
-| **Human Likeness (HPDR-5)** | How natural and human the AI sounds |
-| **MOS** | Mean Opinion Score — overall quality rating |
-| **Emotional Match Accuracy** | How well the AI matches appropriate emotions |
-| **Valence/Arousal** | Emotional intensity and positivity analysis |
-| **Prosody Expressiveness** | Speech rhythm, intonation, and expression quality |
-| **Speaker Consistency** | Voice consistency across the conversation |
+- Pitch Variance
+- Jitter
+- Shimmer
+- HNR
 
-### How They Work
+Method:
 
-Qualitative metrics use an LLM to analyze the conversation transcript and audio characteristics, providing subjective assessments that would normally require human evaluation.
+- Computed from recorded audio signal characteristics.
 
----
+### 3) AI voice quality metrics (model-based audio quality)
 
-## Custom Metrics
+Examples:
 
-You can define your own custom metrics for specific use cases:
+- MOS Score
+- Emotion Category
+- Emotion Confidence
+- Valence
+- Arousal
+- Speaker Consistency
+- Prosody Score
 
-- **Rating Type**: Score on a scale (e.g., 1-5)
-- **Boolean Type**: Pass/fail assessment
+Method:
 
-### Examples
-- "Resolution Success" — Did the AI solve the customer's problem?
-- "Empathy Score" — Was the AI appropriately empathetic?
-- "Upsell Attempted" — Did the AI try to upsell?
+- Uses audio-based ML evaluation for quality, emotion, and consistency.
 
----
+## Default behavior notes
 
-## Storage
+By default:
 
-Metric results are stored in the `metric_scores` JSON column of the `EvaluatorResult` database table and can be viewed in the Results Dashboard.
+- `Pitch Variance` starts enabled.
+- `Jitter`, `Shimmer`, and `HNR` start disabled.
+
+You can enable or disable metrics from the Metrics page at any time.
+
+## How metrics are applied during processing
+
+1. Call audio and transcript are collected.
+2. Enabled metrics are split by evaluation method.
+3. Audio-required metrics run only when audio is available.
+4. LLM metrics run on transcript and context.
+5. Scores are written to evaluator results for reporting and comparison.
+
+If audio is missing, audio-dependent metrics are skipped instead of being fabricated.

--- a/EfficientAI-Docs/docs/products/personas.md
+++ b/EfficientAI-Docs/docs/products/personas.md
@@ -6,50 +6,43 @@ sidebar_position: 2
 
 # Personas
 
-## What is a Persona?
+A Persona is the caller profile used to test your agent.
 
-A **Persona** is a simulated character. It's the "Actor" that calls your AI.
+## Persona = profile + mapped voice
 
-When you test your Voice AI, you don't want every test call to sound the same. A real customer base is diverse—some speak fast, some possess strong accents, and some call from noisy cafes.
+Each persona is explicitly mapped to a concrete voice identity:
 
-With Personas, you can create characters like:
-*   **"John"**: Speaks English with a standard American accent, calling from a quiet office.
-*   **"Maria"**: Speaks Spanish, calling from a noisy street.
-*   **"Raj"**: Speaks English with an Indian accent.
+- `tts_provider`
+- `tts_voice_id`
+- `tts_voice_name`
+- `gender`
 
-By testing with different Personas, you ensure your AI works for *everyone*, not just people with perfect studio microphones.
+This keeps test behavior realistic and reproducible across repeated runs.
 
----
+## Voice sources
 
-## Technical Details
+Personas can use:
 
-Personas represent the simulated users that interact with your Voice AI agents. They are configured with specific demographic and environmental characteristics to test how well your agent handles variety in speech patterns, accents, and acoustic environments.
+- built-in provider voices, or
+- custom voices registered by your organization.
 
-### Configuration
+Custom voices appear in the same selection flow as built-in voices during persona creation and edits.
 
-A Persona is defined by the following attributes:
+## Why this matters
 
-| Attribute | Type | Description |
-|---|---|---|
-| `name` | String | A friendly name for the persona (e.g., "John Doe - American Male"). |
-| `language` | Enum | The primary language spoken by the persona. |
-| `accent` | Enum | The specific accent of the persona, used to test speech recognition robustness. |
-| `gender` | Enum | The gender of the voice (Male, Female, Neutral). |
-| `background_noise` | Enum | Simulated environmental noise added to the audio stream. |
+Persona voice mapping enables:
 
-### Attribute Definitions
+- consistent replay of the same caller profile,
+- cleaner comparison across model and prompt changes,
+- easier debugging when quality shifts between runs.
 
-#### Languages
-Supported languages: `en` (English), `es` (Spanish), `fr` (French), `de` (German), `zh` (Chinese), `ja` (Japanese), `hi` (Hindi), `ar` (Arabic).
+## Persona fields
 
-#### Accents
-Accents determine the prosody and pronunciation nuances of the Text-to-Speech (TTS) voice used: `american`, `british`, `australian`, `indian`, `chinese`, `spanish`, `french`, `german`, `neutral`.
-
-#### Background Noise
-To simulate real-world conditions, varied acoustic environments can be applied:
-- `none`: Clean studio audio.
-- `office`: Typical office ambience.
-- `street`: Outdoor urban environment.
-- `cafe`: Coffee shop environment.
-- `home`: Indoor residential environment.
-- `call_center`: Busy call center background.
+| Field | Description |
+|---|---|
+| `name` | Persona label used in tests. |
+| `gender` | Persona gender metadata. |
+| `tts_provider` | Voice provider used for synthesis. |
+| `tts_voice_id` | Provider-specific voice identifier. |
+| `tts_voice_name` | Human-readable voice name. |
+| `is_custom` | Whether the selected voice is from custom catalog. |

--- a/EfficientAI-Docs/docs/products/playground.md
+++ b/EfficientAI-Docs/docs/products/playground.md
@@ -1,0 +1,60 @@
+---
+id: playground
+title: Playground
+sidebar_position: 6
+---
+
+# Playground
+
+The Agent Playground is a real-time environment for quickly testing agents and reviewing outcomes.
+
+## What it does
+
+From one place, you can:
+
+- start live tests,
+- monitor call/test status,
+- inspect transcripts and recordings,
+- observe evaluation progress and metric outcomes.
+
+## Test modes
+
+When an agent is configured, you can run two test modes:
+
+### Voice AI Agent mode
+
+Uses external voice provider configuration and runs a live web call against the provider agent.
+
+Current supported providers:
+
+- Retell
+- Vapi
+- ElevenLabs
+
+Typical flow:
+
+1. Create web call using selected agent.
+2. Connect through provider session/client.
+3. Store call recording metadata.
+4. Poll provider call details (status, transcript, audio).
+5. Create evaluator result and run metric evaluation.
+
+### Test Agent mode
+
+Uses the internal voice-agent path backed by a configured voice bundle.
+
+This is useful for controlled comparisons where you want to test the bundle-defined STT, LLM, and TTS stack.
+
+## Result views
+
+Playground keeps Voice AI Agent and Test Agent runs visible in separate views so teams can inspect each workflow clearly and compare outcomes over time.
+
+## Prerequisites
+
+For external live web-call testing:
+
+- set `call_medium` to `web_call`,
+- configure `voice_ai_integration_id`,
+- configure `voice_ai_agent_id`.
+
+For richer playback and storage workflows, ensure storage is configured.

--- a/EfficientAI-Docs/docs/products/prompt-optimization.md
+++ b/EfficientAI-Docs/docs/products/prompt-optimization.md
@@ -1,0 +1,50 @@
+---
+id: prompt-optimization
+title: Prompt Optimization
+sidebar_position: 7
+---
+
+# Prompt Optimization
+
+Prompt Optimization is an enterprise feature for iteratively improving agent prompts using evaluation feedback.
+
+## What gets optimized
+
+Each run starts from a seed prompt:
+
+- provider prompt, if available, otherwise
+- internal agent description.
+
+The optimizer generates candidate prompts, evaluates them against available examples and enabled metrics, and ranks them by score.
+
+## Run configuration
+
+Common run controls include:
+
+- `max_metric_calls` for evaluation budget
+- `minibatch_size` for examples per iteration
+
+These settings determine optimization depth, runtime, and cost.
+
+## Candidate workflow
+
+For each optimization run:
+
+1. Review generated candidates and their scores.
+2. Compare candidate prompt text against the seed prompt.
+3. **Accept** the candidate you want to promote.
+4. Optionally **Push to Provider** to update the linked external agent prompt.
+
+## Push behavior
+
+When a candidate is pushed:
+
+- EfficientAI updates the prompt in the external provider,
+- updates local agent prompt fields,
+- records push timing for traceability.
+
+## Best practices
+
+- Use representative completed evaluator results as optimization data.
+- Keep enabled metric sets stable while comparing candidates.
+- Review prompt semantics in addition to score before pushing.

--- a/EfficientAI-Docs/docs/products/scenarios.md
+++ b/EfficientAI-Docs/docs/products/scenarios.md
@@ -6,48 +6,34 @@ sidebar_position: 3
 
 # Scenarios
 
-## What is a Scenario?
+A Scenario defines the goal and context for a test conversation.
 
-A **Scenario** is the "Script" or "Mission" for the call.
+## How scenarios are created
 
-If the Persona is the *actor*, the Scenario tells them *what to do*. Without a scenario, the actor wouldn't know why they are calling.
+EfficientAI supports three scenario creation paths:
 
-Examples of Scenarios:
-*   **"Book an Appointment"**: The caller wants to schedule a dentist visit for next Tuesday.
-*   **"Return a Product"**: The caller is angry because their new toaster is broken and wants a refund.
-*   **"Ask a Question"**: The caller simply wants to know your business hours.
+1. **Generate from Agent Prompt (AI-assisted)**  
+   Generate scenario drafts from the selected agent's prompt/description.
+2. **Generate from Call data**  
+   Derive scenario content from call transcripts or call data.
+3. **Create Manually**  
+   Write a fully custom scenario.
 
-EfficientAI gives this script to the simulated caller, and they will try to achieve their goal while talking to your AI.
+## Scenario structure
 
----
+| Field | Description |
+|---|---|
+| `name` | Scenario title. |
+| `description` | What should happen in the conversation. |
+| `required_info` | Structured key/value expectations for the test. |
+| `agent_id` | Optional linked agent for context. |
 
-## Technical Details
+## How scenarios are used
 
-Scenarios define the objective of the conversation. They guide the Persona on what they need to achieve during the call, ensuring that the Test Agent challenges the Voice AI in specific, reproducible ways.
+Scenarios are used to:
 
-### Configuration
+- guide persona behavior during tests,
+- provide evaluation context for scoring,
+- keep testing reproducible across repeated runs.
 
-A Scenario consists of the following fields:
-
-| Field | Type | Description |
-|---|---|---|
-| `name` | String | The name of the scenario. |
-| `description` | String | A high-level description of what should happen. |
-| `required_info` | JSON | A structured list of information the Persona **must** collect or convey during the call. |
-
-### Required Info Structure
-
-The `required_info` field is a JSON object that lists data points necessary for success. This is injected into the System Prompt.
-
-**Example:**
-```json
-{
-  "appointment_date": "next Tuesday",
-  "appointment_time": "morning",
-  "reason": "routine cleaning"
-}
-```
-
-### Scenario Logic
-
-The `TestAgentService` combines the Persona definition with the Scenario details to form a complete System Prompt, instructing the LLM to role-play the specific situation.
+A good scenario is specific enough to be measurable, but open enough to preserve natural conversation flow.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,6 +17,7 @@
         "@vapi-ai/web": "^2.5.2",
         "axios": "^1.6.2",
         "clsx": "^2.1.0",
+        "country-flag-icons": "^1.6.15",
         "date-fns": "^3.0.6",
         "framer-motion": "^11.0.0",
         "lucide-react": "^0.303.0",
@@ -5737,6 +5738,12 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/country-flag-icons": {
+      "version": "1.6.15",
+      "resolved": "https://registry.npmjs.org/country-flag-icons/-/country-flag-icons-1.6.15.tgz",
+      "integrity": "sha512-92HoA8l6DluEidku8tKBftjuFRj4Rv3zDW1lXxCuNnqAxhUSkvso9gM/Afj4F5BnK+wneHIe3ydI+s+4NA29/Q==",
       "license": "MIT"
     },
     "node_modules/cross-spawn": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,15 +9,16 @@
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0"
   },
   "dependencies": {
+    "@elevenlabs/client": "^0.2.0",
     "@heroui/react": "^2.7.8",
     "@heroui/theme": "^2.4.14",
     "@pipecat-ai/client-js": "^1.2.0",
     "@pipecat-ai/websocket-transport": "^1.2.0",
     "@tanstack/react-query": "^5.17.0",
-    "@elevenlabs/client": "^0.2.0",
     "@vapi-ai/web": "^2.5.2",
     "axios": "^1.6.2",
     "clsx": "^2.1.0",
+    "country-flag-icons": "^1.6.15",
     "date-fns": "^3.0.6",
     "framer-motion": "^11.0.0",
     "lucide-react": "^0.303.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -71,6 +71,7 @@ import PromptOptimization from './pages/promptOptimization/PromptOptimization'
 
 // Enterprise
 import EnterpriseUpgrade from './pages/enterprise/EnterpriseUpgrade'
+import { WalkthroughProvider } from './context/WalkthroughContext'
 
 
 function PrivateRoute({ children }: { children: React.ReactNode }) {
@@ -110,7 +111,9 @@ function App() {
           path="/"
           element={
             <PrivateRoute>
-              <Layout />
+              <WalkthroughProvider>
+                <Layout />
+              </WalkthroughProvider>
             </PrivateRoute>
           }
         >

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -37,6 +37,7 @@ import {
 } from 'lucide-react'
 import { useState, useEffect } from 'react'
 import Logo from './Logo'
+import WalkthroughRail from './walkthrough/WalkthroughRail'
 
 interface NavItem {
   name: string
@@ -315,7 +316,12 @@ export default function Layout() {
 
         {/* Page content */}
         <main className="flex-1 p-6">
-          <Outlet />
+          <div className="flex min-h-[calc(100vh-7rem)] items-start gap-4">
+            <div className="min-w-0 flex-1">
+              <Outlet />
+            </div>
+            <WalkthroughRail />
+          </div>
         </main>
       </div>
     </div>

--- a/frontend/src/components/walkthrough/WalkthroughRail.tsx
+++ b/frontend/src/components/walkthrough/WalkthroughRail.tsx
@@ -1,6 +1,19 @@
+import type { ComponentType } from 'react'
 import { Link } from 'react-router-dom'
-import { MapPinned } from 'lucide-react'
+import { Bot, FileText, Mic, Plug, Sparkles, Users, Volume2 } from 'lucide-react'
 import { useWalkthrough } from '../../context/WalkthroughContext'
+import type { WalkthroughSectionId } from './walkthroughRegistry'
+
+const sectionIcons: Record<WalkthroughSectionId, ComponentType<{ className?: string }>> = {
+  integrations: Plug,
+  voicebundles: Mic,
+  agents: Bot,
+  personas: Users,
+  scenarios: FileText,
+  evaluators: Mic,
+  'voice-playground': Volume2,
+  'prompt-optimization': Sparkles,
+}
 
 export default function WalkthroughRail() {
   const { activeDefinition, isCollapsed, toggleCollapsed } = useWalkthrough()
@@ -9,9 +22,11 @@ export default function WalkthroughRail() {
     return null
   }
 
+  const SectionIcon = sectionIcons[activeDefinition.id]
+
   return (
     <aside
-      className={`hidden lg:flex shrink-0 transition-[width] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none ${
+      className={`hidden lg:flex shrink-0 relative z-[10050] transition-[width] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none ${
         isCollapsed ? 'w-14' : 'w-[340px]'
       }`}
       aria-label="Section walkthrough"
@@ -21,17 +36,19 @@ export default function WalkthroughRail() {
           <button
             type="button"
             onClick={toggleCollapsed}
-            className="group inline-flex h-10 w-10 items-center justify-center rounded-xl border border-gray-200/90 bg-white text-primary-700 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:border-primary-300 hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-300"
+            className="group inline-flex h-10 w-10 items-center justify-center rounded-xl border border-amber-500 bg-amber-500 text-white shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:bg-amber-600 hover:border-amber-600 hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-300"
             aria-label="Expand walkthrough"
           >
-            <MapPinned className="h-4 w-4 transition-transform duration-200 group-hover:scale-105" />
+            <SectionIcon className="h-4 w-4 transition-transform duration-200 group-hover:scale-105" />
           </button>
         </div>
       ) : (
-        <div className="h-full w-full rounded-xl border border-gray-200/90 bg-white/95 shadow-sm backdrop-blur-sm flex flex-col min-h-0 overflow-hidden">
+        <div className="h-full w-full rounded-xl border border-gray-200/90 bg-white/95 shadow-sm flex flex-col min-h-0 overflow-hidden">
           <div className="flex items-center justify-between gap-2 border-b border-gray-200 p-3">
             <div className="flex items-center gap-2 min-w-0">
-              <MapPinned className="h-4 w-4 text-primary-600 shrink-0" />
+              <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-amber-500 text-white shrink-0 shadow-sm">
+                <SectionIcon className="h-3.5 w-3.5" />
+              </span>
               <h2 className="text-sm font-semibold text-gray-900 truncate">
                 {activeDefinition.title}
               </h2>
@@ -39,10 +56,10 @@ export default function WalkthroughRail() {
             <button
               type="button"
               onClick={toggleCollapsed}
-              className="rounded-md border border-gray-200 bg-white p-1 text-gray-500 transition-colors hover:text-primary-700 hover:bg-gray-50"
+              className="rounded-md border border-amber-500 bg-amber-500 p-1 text-white transition-colors hover:bg-amber-600 hover:border-amber-600"
               aria-label="Collapse walkthrough"
             >
-              <MapPinned className="h-4 w-4" />
+              <SectionIcon className="h-4 w-4" />
             </button>
           </div>
           <div className="flex-1 overflow-y-auto p-3">

--- a/frontend/src/components/walkthrough/WalkthroughRail.tsx
+++ b/frontend/src/components/walkthrough/WalkthroughRail.tsx
@@ -1,0 +1,87 @@
+import { Link } from 'react-router-dom'
+import { MapPinned } from 'lucide-react'
+import { useWalkthrough } from '../../context/WalkthroughContext'
+
+export default function WalkthroughRail() {
+  const { activeDefinition, isCollapsed, toggleCollapsed } = useWalkthrough()
+
+  if (!activeDefinition) {
+    return null
+  }
+
+  return (
+    <aside
+      className={`hidden lg:flex shrink-0 transition-[width] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none ${
+        isCollapsed ? 'w-14' : 'w-[340px]'
+      }`}
+      aria-label="Section walkthrough"
+    >
+      {isCollapsed ? (
+        <div className="w-full pt-2 flex justify-center">
+          <button
+            type="button"
+            onClick={toggleCollapsed}
+            className="group inline-flex h-10 w-10 items-center justify-center rounded-xl border border-gray-200/90 bg-white text-primary-700 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:border-primary-300 hover:shadow-md focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-300"
+            aria-label="Expand walkthrough"
+          >
+            <MapPinned className="h-4 w-4 transition-transform duration-200 group-hover:scale-105" />
+          </button>
+        </div>
+      ) : (
+        <div className="h-full w-full rounded-xl border border-gray-200/90 bg-white/95 shadow-sm backdrop-blur-sm flex flex-col min-h-0 overflow-hidden">
+          <div className="flex items-center justify-between gap-2 border-b border-gray-200 p-3">
+            <div className="flex items-center gap-2 min-w-0">
+              <MapPinned className="h-4 w-4 text-primary-600 shrink-0" />
+              <h2 className="text-sm font-semibold text-gray-900 truncate">
+                {activeDefinition.title}
+              </h2>
+            </div>
+            <button
+              type="button"
+              onClick={toggleCollapsed}
+              className="rounded-md border border-gray-200 bg-white p-1 text-gray-500 transition-colors hover:text-primary-700 hover:bg-gray-50"
+              aria-label="Collapse walkthrough"
+            >
+              <MapPinned className="h-4 w-4" />
+            </button>
+          </div>
+          <div className="flex-1 overflow-y-auto p-3">
+            <p className="text-xs text-gray-600 mb-3">{activeDefinition.subtitle}</p>
+            <ol className="space-y-3">
+              {activeDefinition.steps.map((step, index) => (
+                <li key={`${activeDefinition.id}-${step.title}`}>
+                  <div className="rounded-lg border border-gray-200 bg-gray-50/50 p-3">
+                    <div className="flex items-start gap-2">
+                      <span className="mt-0.5 inline-flex h-5 w-5 items-center justify-center rounded-full bg-primary-100 text-[11px] font-semibold text-primary-700">
+                        {index + 1}
+                      </span>
+                      <div className="min-w-0 flex-1">
+                        <p className="text-sm font-semibold text-gray-900">{step.title}</p>
+                        <p className="mt-1 text-xs text-gray-700">{step.description}</p>
+                        {step.bullets && step.bullets.length > 0 && (
+                          <ul className="mt-2 list-disc pl-4 text-xs text-gray-600 space-y-1">
+                            {step.bullets.map((bullet) => (
+                              <li key={bullet}>{bullet}</li>
+                            ))}
+                          </ul>
+                        )}
+                        {step.ctaLabel && step.ctaPath && (
+                          <Link
+                            to={step.ctaPath}
+                            className="inline-flex items-center mt-2 text-xs font-medium text-primary-700 hover:text-primary-800"
+                          >
+                            {step.ctaLabel}
+                          </Link>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                </li>
+              ))}
+            </ol>
+          </div>
+        </div>
+      )}
+    </aside>
+  )
+}

--- a/frontend/src/components/walkthrough/walkthroughRegistry.ts
+++ b/frontend/src/components/walkthrough/walkthroughRegistry.ts
@@ -56,6 +56,11 @@ export type WalkthroughSectionStateMap = Partial<{
   'prompt-optimization': PromptOptimizationWalkthroughState
 }>
 
+const walkthroughEnterpriseFeatures: Partial<Record<WalkthroughSectionId, string>> = {
+  'voice-playground': 'voice_playground',
+  'prompt-optimization': 'gepa_optimization',
+}
+
 const simpleWalkthroughs: Record<
   Exclude<WalkthroughSectionId, 'scenarios' | 'evaluators' | 'voice-playground' | 'prompt-optimization'>,
   WalkthroughDefinition
@@ -572,4 +577,8 @@ export function getWalkthroughDefinition(
     default:
       return simpleWalkthroughs[sectionId]
   }
+}
+
+export function getWalkthroughEnterpriseFeature(sectionId: WalkthroughSectionId): string | null {
+  return walkthroughEnterpriseFeatures[sectionId] ?? null
 }

--- a/frontend/src/components/walkthrough/walkthroughRegistry.ts
+++ b/frontend/src/components/walkthrough/walkthroughRegistry.ts
@@ -1,0 +1,575 @@
+export type WalkthroughSectionId =
+  | 'integrations'
+  | 'voicebundles'
+  | 'agents'
+  | 'personas'
+  | 'scenarios'
+  | 'evaluators'
+  | 'voice-playground'
+  | 'prompt-optimization'
+
+export type ScenarioCreateMode = 'agent_prompt' | 'call' | 'custom' | null
+export type EvaluatorCreateMode = 'standard' | 'custom'
+export type VoicePlaygroundStep = 'configure' | 'progress' | 'blind-test' | 'results'
+export type VoicePlaygroundTab = 'playground' | 'voices' | 'past-simulations'
+
+export interface WalkthroughStep {
+  title: string
+  description: string
+  bullets?: string[]
+  ctaLabel?: string
+  ctaPath?: string
+}
+
+export interface WalkthroughDefinition {
+  id: WalkthroughSectionId
+  title: string
+  subtitle: string
+  steps: WalkthroughStep[]
+}
+
+export interface ScenariosWalkthroughState {
+  createMode?: ScenarioCreateMode
+}
+
+export interface EvaluatorsWalkthroughState {
+  createMode?: EvaluatorCreateMode
+  showCreateModal?: boolean
+  showRunModal?: boolean
+}
+
+export interface VoicePlaygroundWalkthroughState {
+  activeTab?: VoicePlaygroundTab
+  step?: VoicePlaygroundStep
+}
+
+export interface PromptOptimizationWalkthroughState {
+  hasSelectedRun?: boolean
+  hasCompareCandidate?: boolean
+  showNewRunDialog?: boolean
+}
+
+export type WalkthroughSectionStateMap = Partial<{
+  scenarios: ScenariosWalkthroughState
+  evaluators: EvaluatorsWalkthroughState
+  'voice-playground': VoicePlaygroundWalkthroughState
+  'prompt-optimization': PromptOptimizationWalkthroughState
+}>
+
+const simpleWalkthroughs: Record<
+  Exclude<WalkthroughSectionId, 'scenarios' | 'evaluators' | 'voice-playground' | 'prompt-optimization'>,
+  WalkthroughDefinition
+> = {
+  integrations: {
+    id: 'integrations',
+    title: 'Integrations Walkthrough',
+    subtitle: 'Connect voice platforms and LLM providers first.',
+    steps: [
+      {
+        title: 'Step 1: Choose integration type',
+        description: 'Pick Voice Platform or AI Provider from the Add Integration modal.',
+        bullets: ['Voice Platform powers external call agents', 'AI Provider powers LLM-based generation and evaluation'],
+      },
+      {
+        title: 'Step 2: Add credentials',
+        description: 'Enter API keys for your provider and save the integration.',
+        bullets: ['Vapi requires private + public keys', 'Platform and provider cannot be changed after creation'],
+      },
+      {
+        title: 'Step 3: Verify configured integrations',
+        description: 'Confirm your entries appear under Configured Integrations and are active.',
+        bullets: ['Inactive integrations are not usable in downstream flows', 'Model and voice options depend on these being connected'],
+      },
+    ],
+  },
+  voicebundles: {
+    id: 'voicebundles',
+    title: 'Voice Bundle Walkthrough',
+    subtitle: 'Define the speech + reasoning stack your agent uses.',
+    steps: [
+      {
+        title: 'Step 1: Pick bundle type',
+        description: 'Choose STT+LLM+TTS for a classic pipeline, or S2S for speech-to-speech.',
+        bullets: ['S2S uses one model', 'STT+LLM+TTS exposes separate provider/model controls'],
+      },
+      {
+        title: 'Step 2: Configure providers and models',
+        description: 'Select provider + model per stage, then pick voice for TTS where available.',
+        bullets: ['Missing STT/TTS models usually means provider capability mismatch', 'Provider options come from active integrations'],
+      },
+      {
+        title: 'Step 3: Save and reuse',
+        description: 'Create the VoiceBundle and attach it to agents and evaluator workflows.',
+        bullets: ['Agents can be filtered by voice compatibility later', 'Voice Playground can reuse these defaults'],
+      },
+    ],
+  },
+  agents: {
+    id: 'agents',
+    title: 'Agents Walkthrough',
+    subtitle: 'Create an agent with prompt, call mode, and external provider mapping.',
+    steps: [
+      {
+        title: 'Step 1: Set call behavior',
+        description: 'Choose Web Call or Phone Call, then choose Inbound or Outbound.',
+        bullets: ['Phone Call requires a valid phone number', 'Language and call type should match your use case'],
+      },
+      {
+        title: 'Step 2: Write the test agent prompt',
+        description: 'Use AI Generate if needed, and optionally pull reusable text from Prompt Partials.',
+        bullets: ['Minimum prompt length is enforced', 'Write/Preview modes help validate markdown formatting'],
+      },
+      {
+        title: 'Step 3: Connect voice stack',
+        description: 'Select a Voice Bundle and map the external voice provider agent ID.',
+        bullets: ['Supported providers include Retell, Vapi, and ElevenLabs', 'Agent ID is required to connect external runtime behavior'],
+      },
+    ],
+  },
+  personas: {
+    id: 'personas',
+    title: 'Personas Walkthrough',
+    subtitle: 'Create speaking profiles used during evaluations.',
+    steps: [
+      {
+        title: 'Step 1: Create persona basics',
+        description: 'Set persona name, gender, and TTS provider.',
+        bullets: ['Provider choices come from configured voice integrations', 'Gender can auto-fill from selected voice'],
+      },
+      {
+        title: 'Step 2: Pick a voice',
+        description: 'Select a provider voice from the list and optionally filter by gender.',
+        bullets: ['Voice inventory depends on provider + model availability', 'Persona voice selection affects evaluator compatibility'],
+      },
+      {
+        title: 'Step 3: Add custom voices if needed',
+        description: 'Use Custom Voices tab to register provider-specific voice IDs.',
+        bullets: ['Custom voices become selectable in persona creation', 'You can edit and delete custom voices later'],
+      },
+    ],
+  },
+}
+
+function getScenariosWalkthrough(state?: ScenariosWalkthroughState): WalkthroughDefinition {
+  const mode = state?.createMode
+  if (mode === 'agent_prompt') {
+    return {
+      id: 'scenarios',
+      title: 'Scenarios Walkthrough',
+      subtitle: 'Generate scenarios from the selected agent prompt.',
+      steps: [
+        {
+          title: 'Step 1: Choose generation source',
+          description: 'Select an agent with a strong system prompt and pick scenario count.',
+          bullets: ['Count supports 1-10 drafts', 'Agent prompt quality directly impacts output quality'],
+        },
+        {
+          title: 'Step 2: Select AI provider + model',
+          description: 'Pick LLM provider and model used for scenario generation.',
+          bullets: ['Provider/model must be configured in Integrations', 'Optional context can focus generation on edge cases'],
+        },
+        {
+          title: 'Step 3: Review and save drafts',
+          description: 'Edit generated draft names/descriptions and save selected scenarios.',
+          bullets: ['Each draft can be saved independently', 'Saved scenarios can be linked to evaluators later'],
+        },
+      ],
+    }
+  }
+
+  if (mode === 'call') {
+    return {
+      id: 'scenarios',
+      title: 'Scenarios Walkthrough',
+      subtitle: 'Create scenarios from call transcript or call data.',
+      steps: [
+        {
+          title: 'Step 1: Paste call data',
+          description: 'Use transcript text or call details in Generate from Call mode.',
+          bullets: ['Keep input clean and complete for better extraction', 'Current flow creates a basic scenario structure'],
+        },
+        {
+          title: 'Step 2: Generate scenario',
+          description: 'Run generation and review the generated scenario description.',
+          bullets: ['Use this to turn real interactions into test cases', 'Iterate with cleaner transcripts when needed'],
+        },
+      ],
+    }
+  }
+
+  if (mode === 'custom') {
+    return {
+      id: 'scenarios',
+      title: 'Scenarios Walkthrough',
+      subtitle: 'Manually define custom test scenarios.',
+      steps: [
+        {
+          title: 'Step 1: Enter scenario details',
+          description: 'Provide scenario name and optional linked agent.',
+          bullets: ['Linking an agent can improve traceability', 'Descriptions should be specific and test-oriented'],
+        },
+        {
+          title: 'Step 2: Save scenario',
+          description: 'Create the scenario and verify it appears in Your Scenarios.',
+          bullets: ['Scenarios can be edited later', 'Manual scenarios are best for strict QA scripts'],
+        },
+      ],
+    }
+  }
+
+  return {
+    id: 'scenarios',
+    title: 'Scenarios Walkthrough',
+    subtitle: 'Choose one of three scenario creation modes.',
+    steps: [
+      {
+        title: 'Step 1: Pick creation mode',
+        description: 'Choose Generate from Agent Prompt, Generate from Call, or Create Manually.',
+        bullets: ['Agent Prompt mode is fastest for multiple drafts', 'Manual mode gives full control'],
+      },
+      {
+        title: 'Step 2: Create and refine',
+        description: 'Generate or author scenarios, then edit names and descriptions before use.',
+        bullets: ['Keep scenarios focused on one user intent each', 'Link to agents where useful'],
+      },
+      {
+        title: 'Step 3: Use in evaluators',
+        description: 'Select these scenarios when building evaluators for batch runs.',
+      },
+    ],
+  }
+}
+
+function getEvaluatorsWalkthrough(state?: EvaluatorsWalkthroughState): WalkthroughDefinition {
+  if (state?.showRunModal) {
+    return {
+      id: 'evaluators',
+      title: 'Evaluators Walkthrough',
+      subtitle: 'You are in run configuration mode.',
+      steps: [
+        {
+          title: 'Step 1: Confirm selected evaluators',
+          description: 'Review how many evaluator rows are selected in the run modal.',
+        },
+        {
+          title: 'Step 2: Set run count',
+          description: 'Choose how many times each evaluator should run.',
+          bullets: ['Higher counts increase confidence in consistency', 'Total queued jobs = selected evaluators x run count'],
+        },
+        {
+          title: 'Step 3: Queue runs',
+          description: 'Start the run and monitor background progress from results.',
+        },
+      ],
+    }
+  }
+
+  if (state?.showCreateModal && state?.createMode === 'custom') {
+    return {
+      id: 'evaluators',
+      title: 'Evaluators Walkthrough',
+      subtitle: 'Create custom prompt evaluators for external recordings.',
+      steps: [
+        {
+          title: 'Step 1: Name evaluator + add prompt',
+          description: 'Provide evaluator name and paste full agent prompt/instructions.',
+          bullets: ['Format with AI can structure long prompts', 'Detailed prompts improve evaluation relevance'],
+        },
+        {
+          title: 'Step 2: Select evaluation model',
+          description: 'Choose LLM provider/model for transcript evaluation.',
+          bullets: ['Defaults are used if no provider is configured', 'Model choice affects scoring quality and cost'],
+        },
+        {
+          title: 'Step 3: Create evaluator',
+          description: 'Save custom evaluator and run it against recordings from the table.',
+        },
+      ],
+    }
+  }
+
+  if (state?.showCreateModal) {
+    return {
+      id: 'evaluators',
+      title: 'Evaluators Walkthrough',
+      subtitle: 'Create standard evaluators from agent + persona + scenario.',
+      steps: [
+        {
+          title: 'Step 1: Select agent and scenario',
+          description: 'Pick the target agent and scenario to evaluate.',
+          bullets: ['Scenario should match expected call behavior', 'Evaluator name is optional but recommended'],
+        },
+        {
+          title: 'Step 2: Select personas',
+          description: 'Choose one or more personas compatible with the agent voice bundle.',
+          bullets: ['Incompatible personas may be hidden', 'Each persona creates its own evaluator variant'],
+        },
+        {
+          title: 'Step 3: Save and run',
+          description: 'Create evaluator rows, select them via checkbox, then click Run.',
+        },
+      ],
+    }
+  }
+
+  return {
+    id: 'evaluators',
+    title: 'Evaluators Walkthrough',
+    subtitle: 'Create evaluator configs and run them in batches.',
+    steps: [
+      {
+        title: 'Step 1: Create evaluator',
+        description: 'Use Create Evaluator to add standard or custom prompt evaluators.',
+      },
+      {
+        title: 'Step 2: Select rows',
+        description: 'Use checkboxes to choose evaluators for run or bulk delete.',
+      },
+      {
+        title: 'Step 3: Run in background',
+        description: 'Open Run modal, set run count, and queue jobs.',
+        bullets: ['Progress appears in results views', 'First-time metric model downloads can be slower'],
+      },
+    ],
+  }
+}
+
+function getVoicePlaygroundWalkthrough(state?: VoicePlaygroundWalkthroughState): WalkthroughDefinition {
+  if (state?.activeTab === 'voices') {
+    return {
+      id: 'voice-playground',
+      title: 'Voice Playground Walkthrough',
+      subtitle: 'Manage custom voices for benchmark runs.',
+      steps: [
+        {
+          title: 'Step 1: Add custom voices',
+          description: 'Register provider-specific voice IDs in the Voices tab.',
+        },
+        {
+          title: 'Step 2: Reuse in comparisons',
+          description: 'Custom voices appear in provider voice selectors for benchmarks.',
+        },
+      ],
+    }
+  }
+
+  if (state?.activeTab === 'past-simulations') {
+    return {
+      id: 'voice-playground',
+      title: 'Voice Playground Walkthrough',
+      subtitle: 'Review past simulations and analytics.',
+      steps: [
+        {
+          title: 'Step 1: Open a simulation',
+          description: 'Review side A/B outputs, metrics, and generated artifacts.',
+        },
+        {
+          title: 'Step 2: Compare performance trends',
+          description: 'Use analytics to identify provider/model/voice trends over time.',
+        },
+      ],
+    }
+  }
+
+  if (state?.step === 'progress') {
+    return {
+      id: 'voice-playground',
+      title: 'Voice Playground Walkthrough',
+      subtitle: 'Benchmark is running.',
+      steps: [
+        {
+          title: 'Step 1: Track generation and evaluation',
+          description: 'Watch progress through generating and evaluating samples.',
+        },
+        {
+          title: 'Step 2: Wait for completion',
+          description: 'When done, proceed to blind test or direct results.',
+        },
+      ],
+    }
+  }
+
+  if (state?.step === 'blind-test') {
+    return {
+      id: 'voice-playground',
+      title: 'Voice Playground Walkthrough',
+      subtitle: 'Run blind listening comparison.',
+      steps: [
+        {
+          title: 'Step 1: Listen to X and Y',
+          description: 'For each sample, compare hidden voice outputs.',
+        },
+        {
+          title: 'Step 2: Choose preferred voice',
+          description: 'Submit preferences to produce unbiased comparison data.',
+          bullets: ['You can skip blind test if needed'],
+        },
+      ],
+    }
+  }
+
+  if (state?.step === 'results') {
+    return {
+      id: 'voice-playground',
+      title: 'Voice Playground Walkthrough',
+      subtitle: 'Analyze benchmark outputs.',
+      steps: [
+        {
+          title: 'Step 1: Review scores and samples',
+          description: 'Inspect metrics and listen to generated audio samples.',
+        },
+        {
+          title: 'Step 2: Export report',
+          description: 'Download or generate report artifacts for sharing.',
+        },
+        {
+          title: 'Step 3: Run next comparison',
+          description: 'Reset and iterate with different providers/models/voices.',
+        },
+      ],
+    }
+  }
+
+  return {
+    id: 'voice-playground',
+    title: 'Voice Playground Walkthrough',
+    subtitle: 'Configure benchmark setup before running.',
+    steps: [
+      {
+        title: 'Step 1: Add prompt samples',
+        description: 'Use default prompts, custom text, or AI-generated text samples.',
+        bullets: ['You can save generated prompts to Prompt Partials'],
+      },
+      {
+        title: 'Step 2: Set benchmark configuration',
+        description: 'Select providers, models, voices, sample rates, and run count.',
+        bullets: ['Enable comparison for A/B mode', 'Choose evaluation STT for WER/CER metrics'],
+      },
+      {
+        title: 'Step 3: Run benchmark',
+        description: 'Start benchmark and follow progress into blind-test and results steps.',
+      },
+    ],
+  }
+}
+
+function getPromptOptimizationWalkthrough(
+  state?: PromptOptimizationWalkthroughState
+): WalkthroughDefinition {
+  if (state?.showNewRunDialog) {
+    return {
+      id: 'prompt-optimization',
+      title: 'Prompt Optimization Walkthrough',
+      subtitle: 'Configure a new optimization run.',
+      steps: [
+        {
+          title: 'Step 1: Select agent (and evaluator optionally)',
+          description: 'Choose target agent prompt and optional evaluator context.',
+        },
+        {
+          title: 'Step 2: Set optimization budget',
+          description: 'Tune max metric calls and minibatch size.',
+          bullets: ['Higher budgets improve exploration', 'Minibatch controls examples per iteration'],
+        },
+        {
+          title: 'Step 3: Start run',
+          description: 'Launch optimization and monitor candidate generation in the run list.',
+        },
+      ],
+    }
+  }
+
+  if (!state?.hasSelectedRun) {
+    return {
+      id: 'prompt-optimization',
+      title: 'Prompt Optimization Walkthrough',
+      subtitle: 'Start by selecting or creating a run.',
+      steps: [
+        {
+          title: 'Step 1: Create a run',
+          description: 'Open New Run and choose the target agent prompt to optimize.',
+        },
+        {
+          title: 'Step 2: Wait for candidates',
+          description: 'Optimization runs asynchronously and generates scored candidates.',
+        },
+        {
+          title: 'Step 3: Select a run from the left list',
+          description: 'Open run details to compare seed and optimized prompts.',
+        },
+      ],
+    }
+  }
+
+  if (state?.hasCompareCandidate) {
+    return {
+      id: 'prompt-optimization',
+      title: 'Prompt Optimization Walkthrough',
+      subtitle: 'Compare seed prompt versus optimized candidate.',
+      steps: [
+        {
+          title: 'Step 1: Compare prompts side-by-side',
+          description: 'Review candidate quality and score against the original prompt.',
+        },
+        {
+          title: 'Step 2: Accept best candidate',
+          description: 'Mark one candidate as accepted for deployment.',
+        },
+        {
+          title: 'Step 3: Push to provider',
+          description: 'Push accepted prompt to connected external provider and sync agent prompt.',
+        },
+      ],
+    }
+  }
+
+  return {
+    id: 'prompt-optimization',
+    title: 'Prompt Optimization Walkthrough',
+    subtitle: 'Run, inspect, and deploy optimized prompts.',
+    steps: [
+      {
+        title: 'Step 1: Open run details',
+        description: 'Select a run from the left sidebar to view score and progression.',
+      },
+      {
+        title: 'Step 2: Inspect candidates',
+        description: 'Open candidate cards to evaluate generated prompt variants.',
+      },
+      {
+        title: 'Step 3: Accept and push',
+        description: 'Accept a candidate then push it to your voice provider when ready.',
+      },
+    ],
+  }
+}
+
+export function getWalkthroughSectionId(pathname: string): WalkthroughSectionId | null {
+  if (pathname.startsWith('/integrations')) return 'integrations'
+  if (pathname.startsWith('/voicebundles')) return 'voicebundles'
+  if (pathname.startsWith('/agents')) return 'agents'
+  if (pathname.startsWith('/personas')) return 'personas'
+  if (pathname.startsWith('/scenarios')) return 'scenarios'
+  if (pathname.startsWith('/evaluate-test-agents')) return 'evaluators'
+  if (pathname.startsWith('/voice-playground')) return 'voice-playground'
+  if (pathname.startsWith('/prompt-optimization')) return 'prompt-optimization'
+  return null
+}
+
+export function getWalkthroughDefinition(
+  sectionId: WalkthroughSectionId,
+  state: WalkthroughSectionStateMap
+): WalkthroughDefinition {
+  switch (sectionId) {
+    case 'scenarios':
+      return getScenariosWalkthrough(state.scenarios)
+    case 'evaluators':
+      return getEvaluatorsWalkthrough(state.evaluators)
+    case 'voice-playground':
+      return getVoicePlaygroundWalkthrough(state['voice-playground'])
+    case 'prompt-optimization':
+      return getPromptOptimizationWalkthrough(state['prompt-optimization'])
+    default:
+      return simpleWalkthroughs[sectionId]
+  }
+}

--- a/frontend/src/context/WalkthroughContext.tsx
+++ b/frontend/src/context/WalkthroughContext.tsx
@@ -5,10 +5,10 @@ import {
   WalkthroughSectionId,
   WalkthroughSectionStateMap,
   getWalkthroughDefinition,
+  getWalkthroughEnterpriseFeature,
   getWalkthroughSectionId,
 } from '../components/walkthrough/walkthroughRegistry'
-
-const WALKTHROUGH_COLLAPSED_KEY = 'efficientai.walkthrough.collapsed'
+import { useLicenseStore } from '../store/licenseStore'
 
 interface WalkthroughContextValue {
   isCollapsed: boolean
@@ -28,26 +28,20 @@ const WalkthroughContext = createContext<WalkthroughContextValue | null>(null)
 
 export function WalkthroughProvider({ children }: { children: React.ReactNode }) {
   const location = useLocation()
+  const { enabledFeatures, isLoaded } = useLicenseStore((state) => ({
+    enabledFeatures: state.enabledFeatures,
+    isLoaded: state.isLoaded,
+  }))
   const [isCollapsed, setIsCollapsed] = useState(false)
   const [sectionState, setSectionStateMap] = useState<WalkthroughSectionStateMap>({})
 
-  useEffect(() => {
-    const stored = localStorage.getItem(WALKTHROUGH_COLLAPSED_KEY)
-    if (stored === 'true') {
-      setIsCollapsed(true)
-    }
-  }, [])
-
   const setCollapsed = useCallback((collapsed: boolean) => {
     setIsCollapsed(collapsed)
-    localStorage.setItem(WALKTHROUGH_COLLAPSED_KEY, String(collapsed))
   }, [])
 
   const toggleCollapsed = useCallback(() => {
     setIsCollapsed((prev) => {
-      const next = !prev
-      localStorage.setItem(WALKTHROUGH_COLLAPSED_KEY, String(next))
-      return next
+      return !prev
     })
   }, [])
 
@@ -83,8 +77,14 @@ export function WalkthroughProvider({ children }: { children: React.ReactNode })
     if (!activeSectionId) {
       return null
     }
+
+    const requiredEnterpriseFeature = getWalkthroughEnterpriseFeature(activeSectionId)
+    if (requiredEnterpriseFeature && (!isLoaded || !enabledFeatures.includes(requiredEnterpriseFeature))) {
+      return null
+    }
+
     return getWalkthroughDefinition(activeSectionId, sectionState)
-  }, [activeSectionId, sectionState])
+  }, [activeSectionId, sectionState, isLoaded, enabledFeatures])
 
   const value = useMemo<WalkthroughContextValue>(
     () => ({

--- a/frontend/src/context/WalkthroughContext.tsx
+++ b/frontend/src/context/WalkthroughContext.tsx
@@ -1,0 +1,134 @@
+import { DependencyList, createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
+import { useLocation } from 'react-router-dom'
+import {
+  WalkthroughDefinition,
+  WalkthroughSectionId,
+  WalkthroughSectionStateMap,
+  getWalkthroughDefinition,
+  getWalkthroughSectionId,
+} from '../components/walkthrough/walkthroughRegistry'
+
+const WALKTHROUGH_COLLAPSED_KEY = 'efficientai.walkthrough.collapsed'
+
+interface WalkthroughContextValue {
+  isCollapsed: boolean
+  setCollapsed: (collapsed: boolean) => void
+  toggleCollapsed: () => void
+  activeSectionId: WalkthroughSectionId | null
+  activeDefinition: WalkthroughDefinition | null
+  sectionState: WalkthroughSectionStateMap
+  setSectionState: <K extends keyof WalkthroughSectionStateMap>(
+    sectionId: K,
+    state: WalkthroughSectionStateMap[K]
+  ) => void
+  clearSectionState: (sectionId: keyof WalkthroughSectionStateMap) => void
+}
+
+const WalkthroughContext = createContext<WalkthroughContextValue | null>(null)
+
+export function WalkthroughProvider({ children }: { children: React.ReactNode }) {
+  const location = useLocation()
+  const [isCollapsed, setIsCollapsed] = useState(false)
+  const [sectionState, setSectionStateMap] = useState<WalkthroughSectionStateMap>({})
+
+  useEffect(() => {
+    const stored = localStorage.getItem(WALKTHROUGH_COLLAPSED_KEY)
+    if (stored === 'true') {
+      setIsCollapsed(true)
+    }
+  }, [])
+
+  const setCollapsed = useCallback((collapsed: boolean) => {
+    setIsCollapsed(collapsed)
+    localStorage.setItem(WALKTHROUGH_COLLAPSED_KEY, String(collapsed))
+  }, [])
+
+  const toggleCollapsed = useCallback(() => {
+    setIsCollapsed((prev) => {
+      const next = !prev
+      localStorage.setItem(WALKTHROUGH_COLLAPSED_KEY, String(next))
+      return next
+    })
+  }, [])
+
+  const setSectionState = useCallback(
+    <K extends keyof WalkthroughSectionStateMap>(sectionId: K, state: WalkthroughSectionStateMap[K]) => {
+      setSectionStateMap((prev) => {
+        if (prev[sectionId] === state) {
+          return prev
+        }
+        return { ...prev, [sectionId]: state }
+      })
+    },
+    []
+  )
+
+  const clearSectionState = useCallback((sectionId: keyof WalkthroughSectionStateMap) => {
+    setSectionStateMap((prev) => {
+      if (!(sectionId in prev)) {
+        return prev
+      }
+      const next = { ...prev }
+      delete next[sectionId]
+      return next
+    })
+  }, [])
+
+  const activeSectionId = useMemo(
+    () => getWalkthroughSectionId(location.pathname),
+    [location.pathname]
+  )
+
+  const activeDefinition = useMemo(() => {
+    if (!activeSectionId) {
+      return null
+    }
+    return getWalkthroughDefinition(activeSectionId, sectionState)
+  }, [activeSectionId, sectionState])
+
+  const value = useMemo<WalkthroughContextValue>(
+    () => ({
+      isCollapsed,
+      setCollapsed,
+      toggleCollapsed,
+      activeSectionId,
+      activeDefinition,
+      sectionState,
+      setSectionState,
+      clearSectionState,
+    }),
+    [
+      isCollapsed,
+      setCollapsed,
+      toggleCollapsed,
+      activeSectionId,
+      activeDefinition,
+      sectionState,
+      setSectionState,
+      clearSectionState,
+    ]
+  )
+
+  return <WalkthroughContext.Provider value={value}>{children}</WalkthroughContext.Provider>
+}
+
+export function useWalkthrough(): WalkthroughContextValue {
+  const context = useContext(WalkthroughContext)
+  if (!context) {
+    throw new Error('useWalkthrough must be used within WalkthroughProvider')
+  }
+  return context
+}
+
+export function useWalkthroughSectionState<K extends keyof WalkthroughSectionStateMap>(
+  sectionId: K,
+  state: WalkthroughSectionStateMap[K],
+  deps: DependencyList
+) {
+  const { setSectionState, clearSectionState } = useWalkthrough()
+
+  useEffect(() => {
+    setSectionState(sectionId, state)
+    return () => clearSectionState(sectionId)
+  }, [sectionId, setSectionState, clearSectionState, ...deps])
+}

--- a/frontend/src/pages/evaluators/evaluators/EvaluateTestAgents.tsx
+++ b/frontend/src/pages/evaluators/evaluators/EvaluateTestAgents.tsx
@@ -9,6 +9,7 @@ import ProviderLogo from '../../../components/shared/ProviderLogo'
 import { Plus, Trash2, Play, X, CheckSquare, Square, Sparkles, Brain, ChevronDown, AlertTriangle, Info } from 'lucide-react'
 import { useToast } from '../../../hooks/useToast'
 import { getProviderLabel, getProviderLogo } from '../../../config/providers'
+import { useWalkthroughSectionState } from '../../../context/WalkthroughContext'
 
 const DEFAULT_PERSONA_NAMES = [
   "Grumpy Old Man",
@@ -66,6 +67,12 @@ export default function EvaluateTestAgents() {
   const [selectedLlmModel, setSelectedLlmModel] = useState<string>('')
   const [showLlmDropdown, setShowLlmDropdown] = useState(false)
   const llmDropdownRef = useRef<HTMLDivElement>(null)
+
+  useWalkthroughSectionState(
+    'evaluators',
+    { createMode, showCreateModal, showRunModal },
+    [createMode, showCreateModal, showRunModal]
+  )
 
   const { data: agents = [] } = useQuery({
     queryKey: ['agents'],

--- a/frontend/src/pages/playground/voice/VoicePlayground.tsx
+++ b/frontend/src/pages/playground/voice/VoicePlayground.tsx
@@ -2,6 +2,7 @@ import { Mic, History, Headphones, RotateCcw, X } from 'lucide-react'
 import Button from '../../../components/Button'
 import { VoicePlaygroundProvider, useVoicePlayground } from './context'
 import { PlaygroundTab, VoicesTab, SimulationsTab } from './components'
+import { useWalkthroughSectionState } from '../../../context/WalkthroughContext'
 
 function VoicePlaygroundContent() {
   const {
@@ -15,6 +16,12 @@ function VoicePlaygroundContent() {
     deleteConfirm,
     setDeleteConfirm,
   } = useVoicePlayground()
+
+  useWalkthroughSectionState(
+    'voice-playground',
+    { activeTab, step },
+    [activeTab, step]
+  )
 
   return (
     <div className="space-y-6">

--- a/frontend/src/pages/promptOptimization/PromptOptimization.tsx
+++ b/frontend/src/pages/promptOptimization/PromptOptimization.tsx
@@ -31,6 +31,7 @@ import {
   Globe,
 } from 'lucide-react'
 import { format } from 'date-fns'
+import { useWalkthroughSectionState } from '../../context/WalkthroughContext'
 
 interface OptimizationRun {
   id: string
@@ -131,6 +132,16 @@ export default function PromptOptimization() {
 
   const selectedRun = runs.find(r => r.id === selectedRunId)
   const compareCandidate = candidates.find(c => c.id === compareCandidateId)
+
+  useWalkthroughSectionState(
+    'prompt-optimization',
+    {
+      hasSelectedRun: Boolean(selectedRunId),
+      hasCompareCandidate: Boolean(compareCandidateId),
+      showNewRunDialog,
+    },
+    [selectedRunId, compareCandidateId, showNewRunDialog]
+  )
 
   const createRunMutation = useMutation({
     mutationFn: (data: { agent_id: string; evaluator_id?: string; config?: Record<string, any> }) =>

--- a/frontend/src/pages/scenarios/Scenarios.tsx
+++ b/frontend/src/pages/scenarios/Scenarios.tsx
@@ -7,6 +7,7 @@ import Button from '../../components/Button'
 import { useToast } from '../../hooks/useToast'
 import { AIProvider, ModelProvider } from '../../types/api'
 import { getProviderLabel, getProviderLogo } from '../../config/providers'
+import { useWalkthroughSectionState } from '../../context/WalkthroughContext'
 
 interface Scenario {
   id: string
@@ -70,6 +71,8 @@ export default function Scenarios() {
   const [savingDraftIds, setSavingDraftIds] = useState<Set<string>>(new Set())
   const [editGeneratePrompt, setEditGeneratePrompt] = useState('')
   const [isGeneratingEditDescription, setIsGeneratingEditDescription] = useState(false)
+
+  useWalkthroughSectionState('scenarios', { createMode }, [createMode])
 
   // For Generate from Call
   const [callData, setCallData] = useState('')


### PR DESCRIPTION
## Summary
- Add a persistent right-side walkthrough rail in the authenticated app layout with collapsible state that stays saved in local storage.
- Introduce a route-aware walkthrough registry and context provider so each section (Integrations, Voice Bundles, Agents, Personas, Scenarios, Evaluators, Voice Playground, Prompt Optimization) shows explicit step-by-step guidance.
- Wire dynamic page-state adapters for Scenarios, Evaluators, Voice Playground, and Prompt Optimization so walkthrough content changes with active modes/modals/steps.

## Test plan
- [x] Start frontend and navigate through supported sections to confirm the walkthrough rail appears and updates by route.
- [x] Collapse and expand the rail and verify the state persists after refresh.
- [x] Open create/run flows in Scenarios, Evaluators, Voice Playground, and Prompt Optimization to confirm contextual walkthrough steps update.

Made with [Cursor](https://cursor.com)