### PR TITLE
Security remediation (auth, CSRF, SSRF, rate limits)

### DIFF
--- a/app/api/v1/routes/agents.py
+++ b/app/api/v1/routes/agents.py
@@ -14,6 +14,8 @@ from pydantic import BaseModel
 from loguru import logger
 
 from app.dependencies import get_db, get_organization_id, get_workspace_id, get_api_key
+from app.core.api_rate_limit import enforce_resource_create_rate_limit
+from app.core.auth import Principal
 from app.services.billing.flexprice_service import record_agent_test_setup_generated
 from app.models.database import (
     Agent, ConversationEvaluation, TestAgentConversation, VoiceBundle,
@@ -587,7 +589,8 @@ async def create_agent(
     agent: AgentCreate,
     organization_id: UUID = Depends(get_organization_id),
     workspace_id: UUID = Depends(get_workspace_id),
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
+    _principal: Principal = Depends(enforce_resource_create_rate_limit),
 ):
     """Create a new test agent.
 

--- a/app/api/v1/routes/auth.py
+++ b/app/api/v1/routes/auth.py
@@ -347,6 +347,29 @@ def _revoke_local_password_access_token(bearer: str) -> None:
         pass
 
 
+def _parse_authenticated_org_ids(
+    request: Request,
+    authorization: Optional[str] = None,
+) -> Optional[List]:
+    bearer = _extract_bearer(authorization) or read_access_cookie(request)
+    if not bearer:
+        return None
+    try:
+        claims = decode_access_token(bearer)
+        raw_ids = claims.get("authenticated_org_ids") or []
+        org_ids: List = []
+        for raw in raw_ids:
+            try:
+                from uuid import UUID as _UUID
+
+                org_ids.append(_UUID(str(raw)))
+            except (TypeError, ValueError):
+                continue
+        return org_ids
+    except JWTError:
+        return None
+
+
 def _refresh_ttl_seconds() -> int:
     return settings.AUTH_REFRESH_TOKEN_TTL_DAYS * 24 * 60 * 60
 
@@ -865,6 +888,7 @@ def refresh_session(
     request: Request,
     response: Response,
     payload: Optional[RefreshRequest] = None,
+    authorization: Optional[str] = Header(None, alias="Authorization"),
     db: Session = Depends(get_db),
 ) -> TokenResponse:
     """Rotate a refresh token and issue a new short-lived access token."""
@@ -917,12 +941,17 @@ def refresh_session(
 
     revoke_refresh_token(db, refresh_token)
     role_value = membership.role.value if hasattr(membership.role, "value") else membership.role
+    authenticated_org_ids = _parse_authenticated_org_ids(request, authorization)
+    if authenticated_org_ids is not None:
+        if row.organization_id not in authenticated_org_ids:
+            authenticated_org_ids = [*authenticated_org_ids, row.organization_id]
     return _respond_with_session(
         response,
         db,
         user=user,
         organization_id=row.organization_id,
         role_value=role_value,
+        authenticated_org_ids=authenticated_org_ids,
     )
 
 
@@ -1022,19 +1051,7 @@ def switch_organization(
     if principal.auth_method == AuthMethod.LOCAL_PASSWORD:
         bearer = _extract_bearer(authorization) or read_access_cookie(request)
         if bearer:
-            try:
-                claims = decode_access_token(bearer)
-                raw_ids = claims.get("authenticated_org_ids") or []
-                authenticated_org_ids = []
-                for raw in raw_ids:
-                    try:
-                        from uuid import UUID as _UUID
-
-                        authenticated_org_ids.append(_UUID(str(raw)))
-                    except (TypeError, ValueError):
-                        continue
-            except JWTError:
-                authenticated_org_ids = None
+            authenticated_org_ids = _parse_authenticated_org_ids(request, authorization)
             _revoke_local_password_access_token(bearer)
         old_refresh = payload.refresh_token or read_refresh_cookie(request)
         if old_refresh:

--- a/app/api/v1/routes/auth.py
+++ b/app/api/v1/routes/auth.py
@@ -945,13 +945,17 @@ def set_password(
     if user is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found.")
 
-    # Rotating an existing password - require the current one.
+    # Rotating an existing password - require the current one (400, not 401, so
+    # the SPA does not treat a validation error as an expired session).
     if user.password_hash:
-        if not payload.current_password or not verify_password(
-            payload.current_password, user.password_hash
-        ):
+        if not payload.current_password:
             raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Current password is required.",
+            )
+        if not verify_password(payload.current_password, user.password_hash):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Current password is incorrect.",
             )
 

--- a/app/api/v1/routes/auth.py
+++ b/app/api/v1/routes/auth.py
@@ -38,9 +38,11 @@ from app.core.auth.org_credentials import (
     get_or_create_credential,
     match_password_memberships,
     org_has_password,
+    resolve_current_password_hash,
     resolve_password_hash,
     resolve_session_epoch,
     set_org_password_hash,
+    user_has_any_local_password,
 )
 from app.core.auth.refresh_tokens import (
     issue_refresh_token,
@@ -492,17 +494,17 @@ def signup(
         reference_row = validate_reference_code_for_signup(db, payload.reference_code)
 
     existing = db.query(User).filter(User.email == payload.email).first()
-    if existing and existing.password_hash:
+    if existing and user_has_any_local_password(db, existing):
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail="An account with this email already exists. Try signing in instead.",
         )
 
     _validate_password_or_400(payload.password)
+    password_hash = hash_password(payload.password)
 
-    if existing and not existing.password_hash:
+    if existing and not user_has_any_local_password(db, existing):
         user = existing
-        user.password_hash = hash_password(payload.password)
         if payload.first_name:
             user.first_name = payload.first_name
         if payload.last_name:
@@ -516,7 +518,7 @@ def signup(
     else:
         user = User(
             email=payload.email,
-            password_hash=hash_password(payload.password),
+            password_hash=None,
             first_name=payload.first_name,
             last_name=payload.last_name,
             name=((payload.first_name or "") + " " + (payload.last_name or "")).strip() or None,
@@ -539,7 +541,7 @@ def signup(
             db,
             user=user,
             organization_id=pending_invitation.organization_id,
-            password_hash=user.password_hash,
+            password_hash=password_hash,
         )
         user.last_login_at = datetime.now(timezone.utc)
         db.commit()
@@ -571,7 +573,7 @@ def signup(
         db,
         user=user,
         organization_id=organization.id,
-        password_hash=user.password_hash,
+        password_hash=password_hash,
     )
     provision_default_workspace(
         db,
@@ -620,21 +622,25 @@ def login(
 
     matched_memberships = match_password_memberships(db, user=user, password=payload.password)
     if not matched_memberships:
-        if user.password_hash and verify_password(payload.password, user.password_hash):
-            has_any_membership = (
-                db.query(OrganizationMember)
-                .join(Organization, Organization.id == OrganizationMember.organization_id)
-                .filter(
-                    OrganizationMember.user_id == user.id,
-                    Organization.is_active == True,  # noqa: E712
-                )
-                .first()
+        has_any_membership = (
+            db.query(OrganizationMember)
+            .join(Organization, Organization.id == OrganizationMember.organization_id)
+            .filter(
+                OrganizationMember.user_id == user.id,
+                Organization.is_active == True,  # noqa: E712
             )
-            if has_any_membership is None:
-                raise HTTPException(
-                    status_code=status.HTTP_403_FORBIDDEN,
-                    detail="Your account is not a member of any active organization. Contact your administrator.",
-                )
+            .first()
+        )
+        if has_any_membership is not None:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid email or password.",
+            )
+        if user.password_hash and verify_password(payload.password, user.password_hash):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Your account is not a member of any active organization. Contact your administrator.",
+            )
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid email or password.",
@@ -1089,7 +1095,7 @@ def set_password(
         organization_id=principal.organization_id,
         user=user,
     )
-    current_password_hash = resolve_password_hash(credential, user)
+    current_password_hash = resolve_current_password_hash(credential, user)
 
     if current_password_hash:
         if not payload.current_password:
@@ -1133,9 +1139,6 @@ def set_password(
 
     _validate_password_or_400(payload.new_password)
     new_hash = hash_password(payload.new_password)
-    user.password_hash = new_hash
-    if not user.auth_provider:
-        user.auth_provider = "local"
     set_org_password_hash(credential, new_hash)
     bump_org_session_epoch(credential)
     revoke_refresh_tokens_for_user_org(

--- a/app/api/v1/routes/auth.py
+++ b/app/api/v1/routes/auth.py
@@ -23,7 +23,7 @@ from datetime import datetime, timezone
 from typing import List, Optional, Union
 import secrets
 
-from fastapi import APIRouter, Depends, Header, HTTPException, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Request, Response, status
 from jose import JWTError
 from pydantic import BaseModel, EmailStr, Field
 from sqlalchemy.orm import Session
@@ -37,6 +37,15 @@ from app.core.auth.refresh_tokens import (
     revoke_refresh_token,
     validate_refresh_token,
 )
+from app.core.api_rate_limit import enforce_auth_rate_limit
+from app.core.auth.cookies import (
+    clear_session_cookies,
+    cookie_session_enabled,
+    read_access_cookie,
+    read_refresh_cookie,
+    set_session_cookies,
+)
+from app.core.auth.session_epoch import bump_user_session_epoch
 from app.core.auth.token_revocation import revoke_access_jti
 from app.core.auth.tokens import create_access_token, decode_access_token
 from app.core.license import get_enabled_features, has_auth_feature
@@ -93,6 +102,7 @@ class AuthConfigResponse(BaseModel):
     providers: List[AuthProviderConfig]
     tier: str  # "oss" | "enterprise"
     gated_signup: bool = False
+    cookie_session_enabled: bool = False
 
 
 class SignupRequest(BaseModel):
@@ -175,7 +185,7 @@ class LogoutRequest(BaseModel):
 
 
 class RefreshRequest(BaseModel):
-    refresh_token: str
+    refresh_token: Optional[str] = None
 
 
 LoginResponse = Union[TokenResponse, LoginOrgSelectionResponse]
@@ -237,6 +247,7 @@ def get_auth_config() -> AuthConfigResponse:
             and settings.AUTH_LOCAL_ALLOW_SIGNUP
             and "local_password" in enabled
         ),
+        cookie_session_enabled=cookie_session_enabled(),
     )
 
 
@@ -299,6 +310,10 @@ def _revoke_local_password_access_token(bearer: str) -> None:
         pass
 
 
+def _refresh_ttl_seconds() -> int:
+    return settings.AUTH_REFRESH_TOKEN_TTL_DAYS * 24 * 60 * 60
+
+
 def _issue_session_tokens(
     db: Session,
     *,
@@ -306,10 +321,11 @@ def _issue_session_tokens(
     organization_id,
     role_value: Optional[str],
 ) -> TokenResponse:
-    access_token, _jti, _ttl = create_access_token(
+    access_token, _jti, ttl = create_access_token(
         user_id=user.id,
         organization_id=organization_id,
         email=user.email,
+        session_epoch=int(getattr(user, "session_epoch", 0) or 0),
     )
     refresh_token = issue_refresh_token(
         db,
@@ -320,9 +336,41 @@ def _issue_session_tokens(
     return TokenResponse(
         access_token=access_token,
         refresh_token=refresh_token,
-        expires_in=settings.AUTH_LOCAL_TOKEN_TTL_MINUTES * 60,
+        expires_in=ttl,
         user=_user_to_summary(user, organization_id, role_value),
     )
+
+
+def _respond_with_session(
+    response: Response,
+    db: Session,
+    *,
+    user: User,
+    organization_id,
+    role_value: Optional[str],
+) -> TokenResponse:
+    tokens = _issue_session_tokens(
+        db,
+        user=user,
+        organization_id=organization_id,
+        role_value=role_value,
+    )
+    if cookie_session_enabled():
+        set_session_cookies(
+            response,
+            access_token=tokens.access_token,
+            refresh_token=tokens.refresh_token,
+            access_ttl_seconds=tokens.expires_in,
+            refresh_ttl_seconds=_refresh_ttl_seconds(),
+        )
+        return TokenResponse(
+            access_token="",
+            refresh_token=None,
+            token_type="Bearer",
+            expires_in=tokens.expires_in,
+            user=tokens.user,
+        )
+    return tokens
 
 
 @router.get("/invitations/preview/{token}", response_model=InvitationPreviewResponse)
@@ -338,6 +386,7 @@ def preview_invitation(token: str, db: Session = Depends(get_db)) -> InvitationP
 @router.post("/invitations/accept-by-token", response_model=TokenResponse)
 def accept_invitation_by_token(
     payload: AcceptInviteByTokenRequest,
+    response: Response,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ) -> TokenResponse:
@@ -349,7 +398,8 @@ def accept_invitation_by_token(
         raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
 
     role_value = member.role.value if hasattr(member.role, "value") else member.role
-    return _issue_session_tokens(
+    return _respond_with_session(
+        response,
         db,
         user=current_user,
         organization_id=invitation.organization_id,
@@ -358,14 +408,20 @@ def accept_invitation_by_token(
 
 
 @router.post("/signup", response_model=TokenResponse)
-def signup(payload: SignupRequest, db: Session = Depends(get_db)) -> TokenResponse:
+def signup(
+    payload: SignupRequest,
+    request: Request,
+    response: Response,
+    db: Session = Depends(get_db),
+) -> TokenResponse:
     """
     Create a new User + Organization pair and return a login token.
 
     Only available in OSS/self-hosted deployments where
-    `auth.local_password.allow_signup = true` (the default). Cloud SaaS
+    `auth.local_password.allow_signup = true` (the default).     Cloud SaaS
     turns this off and routes signup through the billing flow.
     """
+    enforce_auth_rate_limit(request)
     _local_password_enabled()
     if not settings.AUTH_LOCAL_ALLOW_SIGNUP:
         raise HTTPException(
@@ -439,7 +495,8 @@ def signup(payload: SignupRequest, db: Session = Depends(get_db)) -> TokenRespon
         db.refresh(user)
 
         role_value = member.role.value if hasattr(member.role, "value") else member.role
-        return _issue_session_tokens(
+        return _respond_with_session(
+            response,
             db,
             user=user,
             organization_id=pending_invitation.organization_id,
@@ -475,7 +532,8 @@ def signup(payload: SignupRequest, db: Session = Depends(get_db)) -> TokenRespon
     db.refresh(organization)
 
     role_value = RoleEnum.ADMIN.value
-    return _issue_session_tokens(
+    return _respond_with_session(
+        response,
         db,
         user=user,
         organization_id=organization.id,
@@ -484,8 +542,14 @@ def signup(payload: SignupRequest, db: Session = Depends(get_db)) -> TokenRespon
 
 
 @router.post("/login", response_model=LoginResponse)
-def login(payload: LoginRequest, db: Session = Depends(get_db)) -> LoginResponse:
+def login(
+    payload: LoginRequest,
+    request: Request,
+    response: Response,
+    db: Session = Depends(get_db),
+) -> LoginResponse:
     """Verify email/password and return a short-lived Bearer token."""
+    enforce_auth_rate_limit(request)
     _local_password_enabled()
 
     user = db.query(User).filter(User.email == payload.email).first()
@@ -580,7 +644,8 @@ def login(payload: LoginRequest, db: Session = Depends(get_db)) -> LoginResponse
     db.commit()
 
     role_value = membership.role.value if hasattr(membership.role, "value") else membership.role
-    return _issue_session_tokens(
+    return _respond_with_session(
+        response,
         db,
         user=user,
         organization_id=target_organization_id,
@@ -615,29 +680,54 @@ def me(principal: Principal = Depends(get_principal), db: Session = Depends(get_
 
 @router.post("/logout")
 def logout(
+    request: Request,
+    response: Response,
     payload: Optional[LogoutRequest] = None,
     authorization: Optional[str] = Header(None, alias="Authorization"),
     principal: Principal = Depends(get_principal),
     db: Session = Depends(get_db),
 ) -> dict:
     """Revoke the current session's refresh token and blacklist the access token."""
-    bearer = _extract_bearer(authorization)
+    bearer = _extract_bearer(authorization) or read_access_cookie(request)
     if bearer and principal.auth_method == AuthMethod.LOCAL_PASSWORD:
         _revoke_local_password_access_token(bearer)
 
+    refresh_token = None
     if payload and payload.refresh_token:
-        revoke_refresh_token(db, payload.refresh_token)
+        refresh_token = payload.refresh_token
+    else:
+        refresh_token = read_refresh_cookie(request)
+    if refresh_token:
+        revoke_refresh_token(db, refresh_token)
         db.commit()
+
+    if cookie_session_enabled():
+        clear_session_cookies(response)
 
     return {"success": True, "auth_method": principal.auth_method.value}
 
 
 @router.post("/refresh", response_model=TokenResponse)
-def refresh_session(payload: RefreshRequest, db: Session = Depends(get_db)) -> TokenResponse:
+def refresh_session(
+    request: Request,
+    response: Response,
+    payload: Optional[RefreshRequest] = None,
+    db: Session = Depends(get_db),
+) -> TokenResponse:
     """Rotate a refresh token and issue a new short-lived access token."""
     _local_password_enabled()
+    refresh_token = None
+    if payload and payload.refresh_token:
+        refresh_token = payload.refresh_token
+    else:
+        refresh_token = read_refresh_cookie(request)
+    if not refresh_token:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Refresh token is required.",
+        )
     try:
-        row = validate_refresh_token(db, payload.refresh_token)
+        row = validate_refresh_token(db, refresh_token)
     except ValueError as exc:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -672,9 +762,10 @@ def refresh_session(payload: RefreshRequest, db: Session = Depends(get_db)) -> T
             detail="Organization disabled.",
         )
 
-    revoke_refresh_token(db, payload.refresh_token)
+    revoke_refresh_token(db, refresh_token)
     role_value = membership.role.value if hasattr(membership.role, "value") else membership.role
-    return _issue_session_tokens(
+    return _respond_with_session(
+        response,
         db,
         user=user,
         organization_id=row.organization_id,
@@ -707,6 +798,8 @@ class SwitchOrgRequest(BaseModel):
 @router.post("/switch-org", response_model=TokenResponse)
 def switch_organization(
     payload: SwitchOrgRequest,
+    response: Response,
+    request: Request,
     principal: Principal = Depends(get_principal),
     authorization: Optional[str] = Header(None, alias="Authorization"),
     db: Session = Depends(get_db),
@@ -773,11 +866,12 @@ def switch_organization(
         )
 
     if principal.auth_method == AuthMethod.LOCAL_PASSWORD:
-        bearer = _extract_bearer(authorization)
+        bearer = _extract_bearer(authorization) or read_access_cookie(request)
         if bearer:
             _revoke_local_password_access_token(bearer)
-        if payload.refresh_token:
-            revoke_refresh_token(db, payload.refresh_token)
+        old_refresh = payload.refresh_token or read_refresh_cookie(request)
+        if old_refresh:
+            revoke_refresh_token(db, old_refresh)
 
     user.last_login_at = datetime.now(timezone.utc)
     db.commit()
@@ -786,7 +880,8 @@ def switch_organization(
     role_value = (
         membership.role.value if hasattr(membership.role, "value") else membership.role
     )
-    return _issue_session_tokens(
+    return _respond_with_session(
+        response,
         db,
         user=user,
         organization_id=membership.organization_id,
@@ -820,6 +915,7 @@ class SetPasswordRequest(BaseModel):
 @router.post("/password", response_model=UserSummary)
 def set_password(
     payload: SetPasswordRequest,
+    response: Response,
     principal: Principal = Depends(get_principal),
     db: Session = Depends(get_db),
 ) -> UserSummary:
@@ -871,8 +967,8 @@ def set_password(
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=(
-                    "Email can only be changed via this endpoint for accounts "
-                    "created from an API key. Use profile update otherwise."
+                    "Email can only be changed for accounts created from an API key "
+                    "with a placeholder address."
                 ),
             )
         conflict = (
@@ -891,9 +987,13 @@ def set_password(
     user.password_hash = hash_password(payload.new_password)
     if not user.auth_provider:
         user.auth_provider = "local"
+    bump_user_session_epoch(user)
     revoke_all_user_refresh_tokens(db, user.id)
     db.commit()
     db.refresh(user)
+
+    if cookie_session_enabled():
+        clear_session_cookies(response)
 
     # Return the updated summary so the SPA can refresh its local session.
     membership = (

--- a/app/api/v1/routes/auth.py
+++ b/app/api/v1/routes/auth.py
@@ -44,6 +44,7 @@ from app.core.auth.org_credentials import (
     user_has_any_local_password,
 )
 from app.core.auth.refresh_tokens import (
+    authenticated_org_ids_from_refresh_row,
     issue_refresh_token,
     revoke_refresh_token,
     revoke_refresh_tokens_for_user_org,
@@ -58,7 +59,11 @@ from app.core.auth.cookies import (
     set_session_cookies,
 )
 from app.core.auth.token_revocation import revoke_access_jti
-from app.core.auth.tokens import create_access_token, decode_access_token
+from app.core.auth.tokens import (
+    create_access_token,
+    decode_access_token,
+    decode_access_token_allow_expired,
+)
 from app.core.license import get_enabled_features, has_auth_feature
 from app.core.password import hash_password, validate_password_strength, verify_password
 from app.database import get_db
@@ -347,6 +352,19 @@ def _revoke_local_password_access_token(bearer: str) -> None:
         pass
 
 
+def _org_ids_from_token_claims(claims: dict) -> Optional[List]:
+    raw_ids = claims.get("authenticated_org_ids") or []
+    org_ids: List = []
+    for raw in raw_ids:
+        try:
+            from uuid import UUID as _UUID
+
+            org_ids.append(_UUID(str(raw)))
+        except (TypeError, ValueError):
+            continue
+    return org_ids or None
+
+
 def _parse_authenticated_org_ids(
     request: Request,
     authorization: Optional[str] = None,
@@ -354,20 +372,13 @@ def _parse_authenticated_org_ids(
     bearer = _extract_bearer(authorization) or read_access_cookie(request)
     if not bearer:
         return None
-    try:
-        claims = decode_access_token(bearer)
-        raw_ids = claims.get("authenticated_org_ids") or []
-        org_ids: List = []
-        for raw in raw_ids:
-            try:
-                from uuid import UUID as _UUID
-
-                org_ids.append(_UUID(str(raw)))
-            except (TypeError, ValueError):
-                continue
-        return org_ids
-    except JWTError:
-        return None
+    for decoder in (decode_access_token, decode_access_token_allow_expired):
+        try:
+            claims = decoder(bearer)
+            return _org_ids_from_token_claims(claims)
+        except JWTError:
+            continue
+    return None
 
 
 def _refresh_ttl_seconds() -> int:
@@ -401,6 +412,7 @@ def _issue_session_tokens(
         db,
         user_id=user.id,
         organization_id=organization_id,
+        authenticated_org_ids=authenticated_org_id_strings(org_ids),
     )
     db.commit()
     return TokenResponse(
@@ -942,6 +954,8 @@ def refresh_session(
     revoke_refresh_token(db, refresh_token)
     role_value = membership.role.value if hasattr(membership.role, "value") else membership.role
     authenticated_org_ids = _parse_authenticated_org_ids(request, authorization)
+    if authenticated_org_ids is None:
+        authenticated_org_ids = authenticated_org_ids_from_refresh_row(row)
     if authenticated_org_ids is not None:
         if row.organization_id not in authenticated_org_ids:
             authenticated_org_ids = [*authenticated_org_ids, row.organization_id]
@@ -1057,7 +1071,10 @@ def switch_organization(
         if old_refresh:
             revoke_refresh_token(db, old_refresh)
 
-        if authenticated_org_ids is not None and target_org_id not in authenticated_org_ids:
+        if authenticated_org_ids is None:
+            authenticated_org_ids = [principal.organization_id]
+
+        if target_org_id not in authenticated_org_ids:
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="Sign in again with the password for that organization.",

--- a/app/api/v1/routes/auth.py
+++ b/app/api/v1/routes/auth.py
@@ -887,9 +887,12 @@ def establish_oidc_session(
         )
         .first()
     )
-    role_value = None
-    if membership:
-        role_value = membership.role.value if hasattr(membership.role, "value") else membership.role
+    if membership is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You are not a member of this organization.",
+        )
+    role_value = membership.role.value if hasattr(membership.role, "value") else membership.role
 
     user.last_login_at = datetime.now(timezone.utc)
     db.commit()
@@ -926,23 +929,6 @@ def me(principal: Principal = Depends(get_principal), db: Session = Depends(get_
     if membership:
         role_value = membership.role.value if hasattr(membership.role, "value") else membership.role
     return _user_to_summary(user, principal.organization_id, role_value, db=db)
-
-
-@router.get("/event-stream-token")
-def event_stream_token(
-    request: Request,
-    authorization: Optional[str] = Header(None, alias="Authorization"),
-    principal: Principal = Depends(get_principal),
-) -> dict:
-    """Return a bearer token for EventSource URLs when using httpOnly cookie sessions."""
-    del principal
-    token = _extract_bearer(authorization) or read_access_cookie(request)
-    if not token:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="No access token available for event streams.",
-        )
-    return {"token": token}
 
 
 @router.post("/logout")

--- a/app/api/v1/routes/auth.py
+++ b/app/api/v1/routes/auth.py
@@ -39,7 +39,6 @@ from app.core.auth.org_credentials import (
     match_password_memberships,
     org_has_password,
     resolve_current_password_hash,
-    resolve_password_hash,
     resolve_session_epoch,
     set_org_password_hash,
     user_has_any_local_password,

--- a/app/api/v1/routes/auth.py
+++ b/app/api/v1/routes/auth.py
@@ -928,6 +928,23 @@ def me(principal: Principal = Depends(get_principal), db: Session = Depends(get_
     return _user_to_summary(user, principal.organization_id, role_value, db=db)
 
 
+@router.get("/event-stream-token")
+def event_stream_token(
+    request: Request,
+    authorization: Optional[str] = Header(None, alias="Authorization"),
+    principal: Principal = Depends(get_principal),
+) -> dict:
+    """Return a bearer token for EventSource URLs when using httpOnly cookie sessions."""
+    del principal
+    token = _extract_bearer(authorization) or read_access_cookie(request)
+    if not token:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="No access token available for event streams.",
+        )
+    return {"token": token}
+
+
 @router.post("/logout")
 def logout(
     request: Request,

--- a/app/api/v1/routes/auth.py
+++ b/app/api/v1/routes/auth.py
@@ -31,10 +31,21 @@ from sqlalchemy.orm import Session
 from app.config import settings
 from app.core.auth import Principal, get_principal
 from app.core.auth.principal import AuthMethod
+from app.core.auth.org_credentials import (
+    authenticated_org_id_strings,
+    bump_org_session_epoch,
+    get_credential,
+    get_or_create_credential,
+    match_password_memberships,
+    org_has_password,
+    resolve_password_hash,
+    resolve_session_epoch,
+    set_org_password_hash,
+)
 from app.core.auth.refresh_tokens import (
     issue_refresh_token,
-    revoke_all_user_refresh_tokens,
     revoke_refresh_token,
+    revoke_refresh_tokens_for_user_org,
     validate_refresh_token,
 )
 from app.core.api_rate_limit import enforce_auth_rate_limit
@@ -45,7 +56,6 @@ from app.core.auth.cookies import (
     read_refresh_cookie,
     set_session_cookies,
 )
-from app.core.auth.session_epoch import bump_user_session_epoch
 from app.core.auth.token_revocation import revoke_access_jti
 from app.core.auth.tokens import create_access_token, decode_access_token
 from app.core.license import get_enabled_features, has_auth_feature
@@ -263,12 +273,20 @@ def _local_password_enabled() -> None:
         )
 
 
-def _user_to_summary(user: User, organization_id, role: Optional[str]) -> UserSummary:
+def _user_to_summary(
+    user: User,
+    organization_id,
+    role: Optional[str],
+    db: Optional[Session] = None,
+) -> UserSummary:
     email_is_placeholder = bool(
         user.email
         and user.email.startswith("api_user_")
         and user.email.endswith("@efficientai.local")
     )
+    has_password = bool(user.password_hash)
+    if db is not None:
+        has_password = org_has_password(db, user=user, organization_id=organization_id)
     return UserSummary(
         id=str(user.id),
         email=user.email,
@@ -277,7 +295,7 @@ def _user_to_summary(user: User, organization_id, role: Optional[str]) -> UserSu
         last_name=user.last_name,
         organization_id=str(organization_id),
         role=role,
-        has_password=bool(user.password_hash),
+        has_password=has_password,
         email_is_placeholder=email_is_placeholder,
     )
 
@@ -287,6 +305,22 @@ def _validate_password_or_400(password: str) -> None:
         validate_password_strength(password)
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+
+def _set_org_credential_password(
+    db: Session,
+    *,
+    user: User,
+    organization_id,
+    password_hash: str,
+) -> None:
+    credential = get_or_create_credential(
+        db,
+        user_id=user.id,
+        organization_id=organization_id,
+        user=user,
+    )
+    set_org_password_hash(credential, password_hash)
 
 
 def _extract_bearer(authorization: Optional[str]) -> Optional[str]:
@@ -320,12 +354,21 @@ def _issue_session_tokens(
     user: User,
     organization_id,
     role_value: Optional[str],
+    authenticated_org_ids: Optional[List] = None,
 ) -> TokenResponse:
+    credential = get_or_create_credential(
+        db,
+        user_id=user.id,
+        organization_id=organization_id,
+        user=user,
+    )
+    org_ids = authenticated_org_ids or [organization_id]
     access_token, _jti, ttl = create_access_token(
         user_id=user.id,
         organization_id=organization_id,
         email=user.email,
-        session_epoch=int(getattr(user, "session_epoch", 0) or 0),
+        session_epoch=resolve_session_epoch(credential, user),
+        authenticated_org_ids=authenticated_org_id_strings(org_ids),
     )
     refresh_token = issue_refresh_token(
         db,
@@ -337,7 +380,7 @@ def _issue_session_tokens(
         access_token=access_token,
         refresh_token=refresh_token,
         expires_in=ttl,
-        user=_user_to_summary(user, organization_id, role_value),
+        user=_user_to_summary(user, organization_id, role_value, db=db),
     )
 
 
@@ -348,12 +391,14 @@ def _respond_with_session(
     user: User,
     organization_id,
     role_value: Optional[str],
+    authenticated_org_ids: Optional[List] = None,
 ) -> TokenResponse:
     tokens = _issue_session_tokens(
         db,
         user=user,
         organization_id=organization_id,
         role_value=role_value,
+        authenticated_org_ids=authenticated_org_ids,
     )
     if cookie_session_enabled():
         set_session_cookies(
@@ -490,6 +535,12 @@ def signup(
         )
         if reference_row is not None:
             consume_reference_code(db, reference_row)
+        _set_org_credential_password(
+            db,
+            user=user,
+            organization_id=pending_invitation.organization_id,
+            password_hash=user.password_hash,
+        )
         user.last_login_at = datetime.now(timezone.utc)
         db.commit()
         db.refresh(user)
@@ -501,6 +552,7 @@ def signup(
             user=user,
             organization_id=pending_invitation.organization_id,
             role_value=role_value,
+            authenticated_org_ids=[pending_invitation.organization_id],
         )
 
     org_name = (payload.organization_name or payload.email.split("@")[0] + "'s Org").strip()
@@ -514,6 +566,13 @@ def signup(
         role=RoleEnum.ADMIN.value,
     )
     db.add(membership)
+    db.flush()
+    _set_org_credential_password(
+        db,
+        user=user,
+        organization_id=organization.id,
+        password_hash=user.password_hash,
+    )
     provision_default_workspace(
         db,
         organization_id=organization.id,
@@ -553,29 +612,35 @@ def login(
     _local_password_enabled()
 
     user = db.query(User).filter(User.email == payload.email).first()
-    if (
-        user is None
-        or not user.is_active
-        or not user.password_hash
-        or not verify_password(payload.password, user.password_hash)
-    ):
-        # Same error regardless of whether the email exists - don't leak
-        # whether an email is registered.
+    if user is None or not user.is_active:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid email or password.",
         )
 
-    memberships = (
-        db.query(OrganizationMember, Organization)
-        .join(Organization, Organization.id == OrganizationMember.organization_id)
-        .filter(
-            OrganizationMember.user_id == user.id,
-            Organization.is_active == True,  # noqa: E712
+    matched_memberships = match_password_memberships(db, user=user, password=payload.password)
+    if not matched_memberships:
+        if user.password_hash and verify_password(payload.password, user.password_hash):
+            has_any_membership = (
+                db.query(OrganizationMember)
+                .join(Organization, Organization.id == OrganizationMember.organization_id)
+                .filter(
+                    OrganizationMember.user_id == user.id,
+                    Organization.is_active == True,  # noqa: E712
+                )
+                .first()
+            )
+            if has_any_membership is None:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="Your account is not a member of any active organization. Contact your administrator.",
+                )
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid email or password.",
         )
-        .order_by(OrganizationMember.joined_at.asc())
-        .all()
-    )
+
+    memberships = matched_memberships
 
     invite_token = (payload.invite_token or "").strip() or None
     if not memberships and invite_token:
@@ -602,6 +667,8 @@ def login(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Your account is not a member of any active organization. Contact your administrator.",
         )
+
+    authenticated_org_ids = [member.organization_id for member, _org in memberships]
 
     if len(memberships) > 1 and not payload.organization_id:
         org_options: List[LoginOrgOption] = []
@@ -632,8 +699,8 @@ def login(
         )
         if membership is None:
             raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="You are not a member of the selected organization.",
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid email or password.",
             )
         target_organization_id = membership.organization_id
     else:
@@ -650,6 +717,7 @@ def login(
         user=user,
         organization_id=target_organization_id,
         role_value=role_value,
+        authenticated_org_ids=authenticated_org_ids,
     )
 
 
@@ -724,7 +792,7 @@ def me(principal: Principal = Depends(get_principal), db: Session = Depends(get_
     role_value = None
     if membership:
         role_value = membership.role.value if hasattr(membership.role, "value") else membership.role
-    return _user_to_summary(user, principal.organization_id, role_value)
+    return _user_to_summary(user, principal.organization_id, role_value, db=db)
 
 
 @router.post("/logout")
@@ -914,13 +982,33 @@ def switch_organization(
             detail="User is no longer active.",
         )
 
+    authenticated_org_ids: Optional[List] = None
     if principal.auth_method == AuthMethod.LOCAL_PASSWORD:
         bearer = _extract_bearer(authorization) or read_access_cookie(request)
         if bearer:
+            try:
+                claims = decode_access_token(bearer)
+                raw_ids = claims.get("authenticated_org_ids") or []
+                authenticated_org_ids = []
+                for raw in raw_ids:
+                    try:
+                        from uuid import UUID as _UUID
+
+                        authenticated_org_ids.append(_UUID(str(raw)))
+                    except (TypeError, ValueError):
+                        continue
+            except JWTError:
+                authenticated_org_ids = None
             _revoke_local_password_access_token(bearer)
         old_refresh = payload.refresh_token or read_refresh_cookie(request)
         if old_refresh:
             revoke_refresh_token(db, old_refresh)
+
+        if authenticated_org_ids is not None and target_org_id not in authenticated_org_ids:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Sign in again with the password for that organization.",
+            )
 
     user.last_login_at = datetime.now(timezone.utc)
     db.commit()
@@ -935,6 +1023,7 @@ def switch_organization(
         user=user,
         organization_id=membership.organization_id,
         role_value=role_value,
+        authenticated_org_ids=authenticated_org_ids or [membership.organization_id],
     )
 
 
@@ -994,15 +1083,21 @@ def set_password(
     if user is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found.")
 
-    # Rotating an existing password - require the current one (400, not 401, so
-    # the SPA does not treat a validation error as an expired session).
-    if user.password_hash:
+    credential = get_or_create_credential(
+        db,
+        user_id=user.id,
+        organization_id=principal.organization_id,
+        user=user,
+    )
+    current_password_hash = resolve_password_hash(credential, user)
+
+    if current_password_hash:
         if not payload.current_password:
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Current password is required.",
             )
-        if not verify_password(payload.current_password, user.password_hash):
+        if not verify_password(payload.current_password, current_password_hash):
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail="Current password is incorrect.",
@@ -1037,11 +1132,17 @@ def set_password(
         user.email = payload.email
 
     _validate_password_or_400(payload.new_password)
-    user.password_hash = hash_password(payload.new_password)
+    new_hash = hash_password(payload.new_password)
+    user.password_hash = new_hash
     if not user.auth_provider:
         user.auth_provider = "local"
-    bump_user_session_epoch(user)
-    revoke_all_user_refresh_tokens(db, user.id)
+    set_org_password_hash(credential, new_hash)
+    bump_org_session_epoch(credential)
+    revoke_refresh_tokens_for_user_org(
+        db,
+        user_id=user.id,
+        organization_id=principal.organization_id,
+    )
     db.commit()
     db.refresh(user)
 
@@ -1062,7 +1163,7 @@ def set_password(
         role_value = (
             membership.role.value if hasattr(membership.role, "value") else membership.role
         )
-    return _user_to_summary(user, principal.organization_id, role_value)
+    return _user_to_summary(user, principal.organization_id, role_value, db=db)
 
 
 # ---------------------------------------------------------------------------

--- a/app/api/v1/routes/auth.py
+++ b/app/api/v1/routes/auth.py
@@ -20,7 +20,7 @@ Covers three concerns:
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import List, Optional, Union
+from typing import Dict, List, Optional, Tuple, Union
 import secrets
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, Response, status
@@ -33,7 +33,9 @@ from app.core.auth import Principal, get_principal
 from app.core.auth.principal import AuthMethod
 from app.core.auth.org_credentials import (
     authenticated_org_id_strings,
+    build_authenticated_org_epochs,
     bump_org_session_epoch,
+    filter_authenticated_orgs_by_epoch,
     get_credential,
     get_or_create_credential,
     match_password_memberships,
@@ -44,10 +46,11 @@ from app.core.auth.org_credentials import (
     user_has_any_local_password,
 )
 from app.core.auth.refresh_tokens import (
-    authenticated_org_ids_from_refresh_row,
+    authenticated_org_auth_from_refresh_row,
     issue_refresh_token,
     revoke_refresh_token,
     revoke_refresh_tokens_for_user_org,
+    strip_org_from_user_refresh_auth,
     validate_refresh_token,
 )
 from app.core.api_rate_limit import enforce_auth_rate_limit
@@ -365,20 +368,68 @@ def _org_ids_from_token_claims(claims: dict) -> Optional[List]:
     return org_ids or None
 
 
+def _epochs_from_token_claims(claims: dict) -> Optional[Dict[str, int]]:
+    raw_epochs = claims.get("authenticated_org_epochs")
+    if not isinstance(raw_epochs, dict):
+        return None
+    epochs: Dict[str, int] = {}
+    for key, value in raw_epochs.items():
+        try:
+            epochs[str(key)] = int(value)
+        except (TypeError, ValueError):
+            continue
+    return epochs or None
+
+
+def _parse_authenticated_org_auth(
+    request: Request,
+    authorization: Optional[str] = None,
+) -> Tuple[Optional[List], Optional[Dict[str, int]]]:
+    bearer = _extract_bearer(authorization) or read_access_cookie(request)
+    if not bearer:
+        return None, None
+    for decoder in (decode_access_token, decode_access_token_allow_expired):
+        try:
+            claims = decoder(bearer)
+            return _org_ids_from_token_claims(claims), _epochs_from_token_claims(claims)
+        except JWTError:
+            continue
+    return None, None
+
+
 def _parse_authenticated_org_ids(
     request: Request,
     authorization: Optional[str] = None,
 ) -> Optional[List]:
-    bearer = _extract_bearer(authorization) or read_access_cookie(request)
-    if not bearer:
-        return None
-    for decoder in (decode_access_token, decode_access_token_allow_expired):
-        try:
-            claims = decoder(bearer)
-            return _org_ids_from_token_claims(claims)
-        except JWTError:
-            continue
-    return None
+    org_ids, _epochs = _parse_authenticated_org_auth(request, authorization)
+    return org_ids
+
+
+def _normalize_authenticated_org_auth(
+    db: Session,
+    user: User,
+    organization_id,
+    org_ids: Optional[List],
+    epochs: Optional[Dict[str, int]],
+) -> Tuple[List, Dict[str, int]]:
+    resolved_ids = list(org_ids or [organization_id])
+    resolved_epochs = dict(
+        epochs or build_authenticated_org_epochs(db, user, resolved_ids)
+    )
+    filtered_ids, filtered_epochs = filter_authenticated_orgs_by_epoch(
+        db, user, resolved_ids, resolved_epochs
+    )
+    credential = get_or_create_credential(
+        db,
+        user_id=user.id,
+        organization_id=organization_id,
+        user=user,
+    )
+    current_epoch = resolve_session_epoch(credential, user)
+    if organization_id not in filtered_ids:
+        filtered_ids = [*filtered_ids, organization_id]
+    filtered_epochs[str(organization_id)] = current_epoch
+    return filtered_ids, filtered_epochs
 
 
 def _refresh_ttl_seconds() -> int:
@@ -392,6 +443,7 @@ def _issue_session_tokens(
     organization_id,
     role_value: Optional[str],
     authenticated_org_ids: Optional[List] = None,
+    authenticated_org_epochs: Optional[Dict[str, int]] = None,
     join_notice: Optional[str] = None,
 ) -> TokenResponse:
     credential = get_or_create_credential(
@@ -400,19 +452,27 @@ def _issue_session_tokens(
         organization_id=organization_id,
         user=user,
     )
-    org_ids = authenticated_org_ids or [organization_id]
+    org_ids, org_epochs = _normalize_authenticated_org_auth(
+        db,
+        user,
+        organization_id,
+        authenticated_org_ids,
+        authenticated_org_epochs,
+    )
     access_token, _jti, ttl = create_access_token(
         user_id=user.id,
         organization_id=organization_id,
         email=user.email,
         session_epoch=resolve_session_epoch(credential, user),
         authenticated_org_ids=authenticated_org_id_strings(org_ids),
+        authenticated_org_epochs=org_epochs,
     )
     refresh_token = issue_refresh_token(
         db,
         user_id=user.id,
         organization_id=organization_id,
         authenticated_org_ids=authenticated_org_id_strings(org_ids),
+        authenticated_org_epochs=org_epochs,
     )
     db.commit()
     return TokenResponse(
@@ -432,6 +492,7 @@ def _respond_with_session(
     organization_id,
     role_value: Optional[str],
     authenticated_org_ids: Optional[List] = None,
+    authenticated_org_epochs: Optional[Dict[str, int]] = None,
     join_notice: Optional[str] = None,
 ) -> TokenResponse:
     tokens = _issue_session_tokens(
@@ -440,6 +501,7 @@ def _respond_with_session(
         organization_id=organization_id,
         role_value=role_value,
         authenticated_org_ids=authenticated_org_ids,
+        authenticated_org_epochs=authenticated_org_epochs,
         join_notice=join_notice,
     )
     if cookie_session_enabled():
@@ -953,12 +1015,20 @@ def refresh_session(
 
     revoke_refresh_token(db, refresh_token)
     role_value = membership.role.value if hasattr(membership.role, "value") else membership.role
-    authenticated_org_ids = _parse_authenticated_org_ids(request, authorization)
+    authenticated_org_ids, authenticated_org_epochs = _parse_authenticated_org_auth(
+        request, authorization
+    )
     if authenticated_org_ids is None:
-        authenticated_org_ids = authenticated_org_ids_from_refresh_row(row)
-    if authenticated_org_ids is not None:
-        if row.organization_id not in authenticated_org_ids:
-            authenticated_org_ids = [*authenticated_org_ids, row.organization_id]
+        authenticated_org_ids, authenticated_org_epochs = authenticated_org_auth_from_refresh_row(
+            row
+        )
+    authenticated_org_ids, authenticated_org_epochs = _normalize_authenticated_org_auth(
+        db,
+        user,
+        row.organization_id,
+        authenticated_org_ids,
+        authenticated_org_epochs,
+    )
     return _respond_with_session(
         response,
         db,
@@ -966,6 +1036,7 @@ def refresh_session(
         organization_id=row.organization_id,
         role_value=role_value,
         authenticated_org_ids=authenticated_org_ids,
+        authenticated_org_epochs=authenticated_org_epochs,
     )
 
 
@@ -1062,10 +1133,13 @@ def switch_organization(
         )
 
     authenticated_org_ids: Optional[List] = None
+    authenticated_org_epochs: Optional[Dict[str, int]] = None
     if principal.auth_method == AuthMethod.LOCAL_PASSWORD:
         bearer = _extract_bearer(authorization) or read_access_cookie(request)
         if bearer:
-            authenticated_org_ids = _parse_authenticated_org_ids(request, authorization)
+            authenticated_org_ids, authenticated_org_epochs = _parse_authenticated_org_auth(
+                request, authorization
+            )
             _revoke_local_password_access_token(bearer)
         old_refresh = payload.refresh_token or read_refresh_cookie(request)
         if old_refresh:
@@ -1073,6 +1147,16 @@ def switch_organization(
 
         if authenticated_org_ids is None:
             authenticated_org_ids = [principal.organization_id]
+            authenticated_org_epochs = build_authenticated_org_epochs(
+                db, user, authenticated_org_ids
+            )
+
+        authenticated_org_ids, authenticated_org_epochs = filter_authenticated_orgs_by_epoch(
+            db,
+            user,
+            authenticated_org_ids,
+            authenticated_org_epochs,
+        )
 
         if target_org_id not in authenticated_org_ids:
             raise HTTPException(
@@ -1094,6 +1178,7 @@ def switch_organization(
         organization_id=membership.organization_id,
         role_value=role_value,
         authenticated_org_ids=authenticated_org_ids or [membership.organization_id],
+        authenticated_org_epochs=authenticated_org_epochs,
     )
 
 
@@ -1205,6 +1290,11 @@ def set_password(
     new_hash = hash_password(payload.new_password)
     set_org_password_hash(credential, new_hash)
     bump_org_session_epoch(credential)
+    strip_org_from_user_refresh_auth(
+        db,
+        user_id=user.id,
+        organization_id=principal.organization_id,
+    )
     revoke_refresh_tokens_for_user_org(
         db,
         user_id=user.id,

--- a/app/api/v1/routes/auth.py
+++ b/app/api/v1/routes/auth.py
@@ -433,13 +433,19 @@ def preview_invitation(token: str, db: Session = Depends(get_db)) -> InvitationP
 def accept_invitation_by_token(
     payload: AcceptInviteByTokenRequest,
     response: Response,
+    principal: Principal = Depends(get_principal),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ) -> TokenResponse:
     """Accept an invitation and return a session scoped to the invited organization."""
     try:
         invitation = get_valid_pending_invitation_by_token(db, payload.token)
-        member = accept_invitation_record(db, invitation, current_user)
+        member = accept_invitation_record(
+            db,
+            invitation,
+            current_user,
+            source_organization_id=principal.organization_id,
+        )
     except InvitationError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
 

--- a/app/api/v1/routes/auth.py
+++ b/app/api/v1/routes/auth.py
@@ -653,6 +653,55 @@ def login(
     )
 
 
+@router.post("/oidc/session", response_model=TokenResponse)
+def establish_oidc_session(
+    response: Response,
+    principal: Principal = Depends(get_principal),
+    db: Session = Depends(get_db),
+) -> TokenResponse:
+    """Exchange a validated external OIDC access token for an app session."""
+    if principal.auth_method != AuthMethod.EXTERNAL_OIDC:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="A valid external OIDC access token is required.",
+        )
+    if not principal.user_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No user is attached to this credential.",
+        )
+
+    user = db.query(User).filter(User.id == principal.user_id).first()
+    if user is None or not user.is_active:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="User account is not active.",
+        )
+
+    membership = (
+        db.query(OrganizationMember)
+        .filter(
+            OrganizationMember.user_id == user.id,
+            OrganizationMember.organization_id == principal.organization_id,
+        )
+        .first()
+    )
+    role_value = None
+    if membership:
+        role_value = membership.role.value if hasattr(membership.role, "value") else membership.role
+
+    user.last_login_at = datetime.now(timezone.utc)
+    db.commit()
+
+    return _respond_with_session(
+        response,
+        db,
+        user=user,
+        organization_id=principal.organization_id,
+        role_value=role_value,
+    )
+
+
 @router.get("/me", response_model=UserSummary)
 def me(principal: Principal = Depends(get_principal), db: Session = Depends(get_db)) -> UserSummary:
     """Return the current authenticated user (Bearer or API key)."""

--- a/app/api/v1/routes/auth.py
+++ b/app/api/v1/routes/auth.py
@@ -81,6 +81,7 @@ from app.services.signup_reference_codes import (
 from app.services.invitation_service import (
     InvitationError,
     accept_invitation as accept_invitation_record,
+    build_invite_join_notice,
     get_invitation_preview,
     get_valid_pending_invitation_by_token,
 )
@@ -164,6 +165,7 @@ class TokenResponse(BaseModel):
     token_type: str = "Bearer"
     expires_in: int  # seconds
     user: "UserSummary"
+    join_notice: Optional[str] = None
 
 
 class UserSummary(BaseModel):
@@ -356,6 +358,7 @@ def _issue_session_tokens(
     organization_id,
     role_value: Optional[str],
     authenticated_org_ids: Optional[List] = None,
+    join_notice: Optional[str] = None,
 ) -> TokenResponse:
     credential = get_or_create_credential(
         db,
@@ -382,6 +385,7 @@ def _issue_session_tokens(
         refresh_token=refresh_token,
         expires_in=ttl,
         user=_user_to_summary(user, organization_id, role_value, db=db),
+        join_notice=join_notice,
     )
 
 
@@ -393,6 +397,7 @@ def _respond_with_session(
     organization_id,
     role_value: Optional[str],
     authenticated_org_ids: Optional[List] = None,
+    join_notice: Optional[str] = None,
 ) -> TokenResponse:
     tokens = _issue_session_tokens(
         db,
@@ -400,6 +405,7 @@ def _respond_with_session(
         organization_id=organization_id,
         role_value=role_value,
         authenticated_org_ids=authenticated_org_ids,
+        join_notice=join_notice,
     )
     if cookie_session_enabled():
         set_session_cookies(
@@ -415,6 +421,7 @@ def _respond_with_session(
             token_type="Bearer",
             expires_in=tokens.expires_in,
             user=tokens.user,
+            join_notice=tokens.join_notice,
         )
     return tokens
 
@@ -449,6 +456,23 @@ def accept_invitation_by_token(
     except InvitationError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
 
+    org = (
+        db.query(Organization)
+        .filter(Organization.id == invitation.organization_id)
+        .first()
+    )
+    org_name = org.name if org else "the organization"
+    source_org_id = principal.organization_id
+    if source_org_id == invitation.organization_id:
+        source_org_id = None
+    join_notice = build_invite_join_notice(
+        db,
+        user=current_user,
+        organization_id=invitation.organization_id,
+        organization_name=org_name,
+        source_organization_id=source_org_id,
+    )
+
     role_value = member.role.value if hasattr(member.role, "value") else member.role
     return _respond_with_session(
         response,
@@ -456,6 +480,7 @@ def accept_invitation_by_token(
         user=current_user,
         organization_id=invitation.organization_id,
         role_value=role_value,
+        join_notice=join_notice,
     )
 
 

--- a/app/api/v1/routes/chat.py
+++ b/app/api/v1/routes/chat.py
@@ -9,6 +9,9 @@ from uuid import UUID, uuid4
 from pydantic import BaseModel
 
 from app.dependencies import get_db, get_organization_id, get_workspace_id
+from app.core.api_rate_limit import enforce_resource_create_rate_limit
+from app.core.auth import Principal
+from app.services.ai.llm_config_safety import sanitize_client_llm_config
 from app.services.ai.llm_service import llm_service
 from app.services.billing.flexprice_service import record_chat_completion
 from app.models.schemas import ModelProvider
@@ -44,7 +47,8 @@ async def chat_completion(
     background_tasks: BackgroundTasks,
     organization_id: UUID = Depends(get_organization_id),
     workspace_id: UUID = Depends(get_workspace_id),
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
+    _principal: Principal = Depends(enforce_resource_create_rate_limit),
 ):
     """Generate a chat completion using the specified AI provider and model."""
     try:
@@ -55,6 +59,7 @@ async def chat_completion(
         )
 
         messages = [{"role": msg.role, "content": msg.content} for msg in request.messages]
+        safe_llm_config = sanitize_client_llm_config(request.llm_config)
 
         with llm_usage_context(
             LLMUsageContext(
@@ -69,7 +74,7 @@ async def chat_completion(
                 llm_model=request.model,
                 organization_id=organization_id,
                 db=db,
-                llm_config=request.llm_config,
+                llm_config=safe_llm_config,
                 temperature=request.temperature,
                 max_tokens=request.max_tokens,
                 task_defaults={"temperature": 0.7},

--- a/app/api/v1/routes/evaluator_results.py
+++ b/app/api/v1/routes/evaluator_results.py
@@ -774,6 +774,14 @@ async def stream_evaluator_result_audio(
     if not audio_url:
         raise HTTPException(status_code=404, detail="No recording available")
 
+    from app.services.telephony.exotel_client import ExotelInvalidContentError
+    from app.services.telephony.recording_download import assert_safe_provider_recording_url
+
+    try:
+        assert_safe_provider_recording_url(str(audio_url))
+    except ExotelInvalidContentError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
     if platform in {"retell", "smallest"}:
         return RedirectResponse(audio_url)
 

--- a/app/api/v1/routes/evaluator_results.py
+++ b/app/api/v1/routes/evaluator_results.py
@@ -1001,6 +1001,18 @@ def re_evaluate_result(
             audio_bytes = None
             decrypted_key = None
 
+            from app.services.telephony.exotel_client import ExotelInvalidContentError
+            from app.services.telephony.recording_download import assert_safe_provider_recording_url
+
+            def _provider_audio_url(url: Optional[str]) -> Optional[str]:
+                if not url:
+                    return None
+                try:
+                    assert_safe_provider_recording_url(str(url))
+                except ExotelInvalidContentError:
+                    return None
+                return str(url)
+
             # Resolve the integration API key (needed for ElevenLabs auth header)
             agent = db.query(Agent).filter(Agent.id == result.agent_id).first() if result.agent_id else None
             if agent and agent.voice_ai_integration_id:
@@ -1012,13 +1024,13 @@ def re_evaluate_result(
                     decrypted_key = decrypt_api_key(integration.api_key)
 
             if platform == "elevenlabs":
-                audio_url = recording_urls.get("conversation_audio")
+                audio_url = _provider_audio_url(recording_urls.get("conversation_audio"))
                 if audio_url and decrypted_key:
                     resp = _http.get(audio_url, headers={"xi-api-key": decrypted_key}, timeout=120)
                     if resp.status_code == 200:
                         audio_bytes = resp.content
             elif platform == "retell":
-                audio_url = call_data.get("recording_url")
+                audio_url = _provider_audio_url(call_data.get("recording_url"))
                 if audio_url:
                     resp = _http.get(audio_url, timeout=120)
                     if resp.status_code == 200:
@@ -1029,7 +1041,7 @@ def re_evaluate_result(
                     is_presigned_storage_url,
                 )
 
-                audio_url = extract_vapi_recording_url(call_data)
+                audio_url = _provider_audio_url(extract_vapi_recording_url(call_data))
                 if audio_url:
                     headers = (
                         None
@@ -1040,7 +1052,7 @@ def re_evaluate_result(
                     if resp.status_code == 200:
                         audio_bytes = resp.content
             elif platform == "smallest":
-                audio_url = (
+                audio_url = _provider_audio_url(
                     call_data.get("recording_url")
                     or call_data.get("recordingUrl")
                     or recording_urls.get("combined_url")

--- a/app/api/v1/routes/iam.py
+++ b/app/api/v1/routes/iam.py
@@ -29,7 +29,7 @@ from app.core.auth.refresh_tokens import (
 )
 from app.core.auth.org_credentials import (
     bump_org_session_epoch,
-    delete_org_credential,
+    revoke_org_membership_credential,
     get_credential,
     get_or_create_credential,
     provision_membership_credential,
@@ -493,7 +493,7 @@ async def remove_user(
         user_id=user_id,
         organization_id=organization_id,
     )
-    delete_org_credential(
+    revoke_org_membership_credential(
         db,
         user_id=user_id,
         organization_id=organization_id,

--- a/app/api/v1/routes/iam.py
+++ b/app/api/v1/routes/iam.py
@@ -4,6 +4,7 @@ Manage users, invitations, and roles within organizations
 """
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 from typing import List, Optional
 from uuid import UUID
@@ -276,13 +277,13 @@ async def invite_user(
     
     if existing_invitation:
         # Check if expired
-        if _to_aware_utc(existing_invitation.expires_at) < datetime.now(timezone.utc):
-            existing_invitation.status = InvitationStatus.EXPIRED
+        if to_aware_utc(existing_invitation.expires_at) < datetime.now(timezone.utc):
+            existing_invitation.status = InvitationStatus.EXPIRED.value
             db.commit()
         else:
             raise HTTPException(
-                status_code=400,
-                detail="An invitation is already pending for this email"
+                status_code=status.HTTP_409_CONFLICT,
+                detail="An invitation is already pending for this email",
             )
     
     # Create invitation
@@ -295,14 +296,21 @@ async def invite_user(
         invited_by_id=current_user.id,
         email=invitation_data.email,
         role=invitation_data.role,
-        status=InvitationStatus.PENDING,
+        status=InvitationStatus.PENDING.value,
         token=invitation_token,
         expires_at=expires_at
     )
     
-    db.add(invitation)
-    db.commit()
-    db.refresh(invitation)
+    try:
+        db.add(invitation)
+        db.commit()
+        db.refresh(invitation)
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="An invitation is already pending for this email",
+        ) from None
     
     org = db.query(Organization).filter(Organization.id == organization_id).first()
 

--- a/app/api/v1/routes/iam.py
+++ b/app/api/v1/routes/iam.py
@@ -23,8 +23,12 @@ from app.models.schemas import (
     RoleUpdate, MessageResponse, UserResponse
 )
 from app.core.password import hash_password, validate_password_strength
-from app.core.auth.refresh_tokens import revoke_all_user_refresh_tokens
-from app.core.auth.session_epoch import bump_user_session_epoch
+from app.core.auth.refresh_tokens import revoke_refresh_tokens_for_user_org
+from app.core.auth.org_credentials import (
+    bump_org_session_epoch,
+    get_or_create_credential,
+    set_org_password_hash,
+)
 from app.services.invitation_service import invitation_to_response_dict, to_aware_utc
 
 router = APIRouter(prefix="/iam", tags=["IAM"])
@@ -536,11 +540,10 @@ async def admin_reset_user_password(
     """
     Reset another organization member's password.
 
-    Requires the caller to be an ADMIN of the organization. The new password
-    is set immediately; existing Bearer tokens for that user remain valid
-    until their natural expiry (the app does not maintain a server-side
-    token revocation list yet). Communicate the new password to the user
-    out-of-band.
+    Requires the caller to be an ADMIN of the organization. Updates the
+    target user's password for this organization only and revokes their
+    refresh tokens for this organization. Sessions in other organizations
+    stay valid.
     """
     if user_id == current_user.id:
         raise HTTPException(
@@ -579,11 +582,19 @@ async def admin_reset_user_password(
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
 
-    target.password_hash = hash_password(payload.new_password)
-    if not target.auth_provider:
-        target.auth_provider = "local"
-    bump_user_session_epoch(target)
-    revoke_all_user_refresh_tokens(db, target.id)
+    credential = get_or_create_credential(
+        db,
+        user_id=target.id,
+        organization_id=organization_id,
+        user=target,
+    )
+    set_org_password_hash(credential, hash_password(payload.new_password))
+    bump_org_session_epoch(credential)
+    revoke_refresh_tokens_for_user_org(
+        db,
+        user_id=target.id,
+        organization_id=organization_id,
+    )
     db.commit()
     db.refresh(target)
 

--- a/app/api/v1/routes/iam.py
+++ b/app/api/v1/routes/iam.py
@@ -23,9 +23,13 @@ from app.models.schemas import (
     RoleUpdate, MessageResponse, UserResponse
 )
 from app.core.password import hash_password, validate_password_strength
-from app.core.auth.refresh_tokens import revoke_refresh_tokens_for_user_org
+from app.core.auth.refresh_tokens import (
+    revoke_refresh_tokens_for_user_org,
+    strip_org_from_user_refresh_auth,
+)
 from app.core.auth.org_credentials import (
     bump_org_session_epoch,
+    delete_org_credential,
     get_credential,
     get_or_create_credential,
     provision_membership_credential,
@@ -484,12 +488,12 @@ async def remove_user(
         organization_id=organization_id,
         user_id=user_id,
     )
-    credential = get_credential(
-        db, user_id=user_id, organization_id=organization_id
-    )
-    if credential is not None:
-        bump_org_session_epoch(credential)
     revoke_refresh_tokens_for_user_org(
+        db,
+        user_id=user_id,
+        organization_id=organization_id,
+    )
+    delete_org_credential(
         db,
         user_id=user_id,
         organization_id=organization_id,
@@ -626,6 +630,11 @@ async def admin_reset_user_password(
     )
     set_org_password_hash(credential, hash_password(payload.new_password))
     bump_org_session_epoch(credential)
+    strip_org_from_user_refresh_auth(
+        db,
+        user_id=target.id,
+        organization_id=organization_id,
+    )
     revoke_refresh_tokens_for_user_org(
         db,
         user_id=target.id,

--- a/app/api/v1/routes/iam.py
+++ b/app/api/v1/routes/iam.py
@@ -23,6 +23,7 @@ from app.models.schemas import (
 )
 from app.core.password import hash_password, validate_password_strength
 from app.core.auth.refresh_tokens import revoke_all_user_refresh_tokens
+from app.core.auth.session_epoch import bump_user_session_epoch
 from app.services.invitation_service import invitation_to_response_dict, to_aware_utc
 
 router = APIRouter(prefix="/iam", tags=["IAM"])
@@ -573,6 +574,7 @@ async def admin_reset_user_password(
     target.password_hash = hash_password(payload.new_password)
     if not target.auth_provider:
         target.auth_provider = "local"
+    bump_user_session_epoch(target)
     revoke_all_user_refresh_tokens(db, target.id)
     db.commit()
     db.refresh(target)

--- a/app/api/v1/routes/iam.py
+++ b/app/api/v1/routes/iam.py
@@ -27,6 +27,7 @@ from app.core.auth.refresh_tokens import revoke_refresh_tokens_for_user_org
 from app.core.auth.org_credentials import (
     bump_org_session_epoch,
     get_or_create_credential,
+    provision_membership_credential,
     set_org_password_hash,
 )
 from app.services.invitation_service import invitation_to_response_dict, to_aware_utc
@@ -63,6 +64,12 @@ def get_user_from_api_key(api_key: str, db: Session) -> User:
                     role=RoleEnum.ADMIN
                 )
                 db.add(member)
+                db.flush()
+                provision_membership_credential(
+                    db,
+                    user_id=user.id,
+                    organization_id=db_key.organization_id,
+                )
                 db.commit()
             
             return user
@@ -90,6 +97,12 @@ def get_user_from_api_key(api_key: str, db: Session) -> User:
             role=RoleEnum.ADMIN
         )
         db.add(member)
+        db.flush()
+        provision_membership_credential(
+            db,
+            user_id=user.id,
+            organization_id=db_key.organization_id,
+        )
         db.commit()
     else:
         # User exists but might not be in organization
@@ -110,6 +123,12 @@ def get_user_from_api_key(api_key: str, db: Session) -> User:
                 role=RoleEnum.ADMIN
             )
             db.add(member)
+            db.flush()
+            provision_membership_credential(
+                db,
+                user_id=user.id,
+                organization_id=db_key.organization_id,
+            )
             db.commit()
     
     return user

--- a/app/api/v1/routes/iam.py
+++ b/app/api/v1/routes/iam.py
@@ -26,11 +26,13 @@ from app.core.password import hash_password, validate_password_strength
 from app.core.auth.refresh_tokens import revoke_refresh_tokens_for_user_org
 from app.core.auth.org_credentials import (
     bump_org_session_epoch,
+    get_credential,
     get_or_create_credential,
     provision_membership_credential,
     set_org_password_hash,
 )
 from app.services.invitation_service import invitation_to_response_dict, to_aware_utc
+from app.services.workspace_rbac import remove_user_org_workspace_memberships
 
 router = APIRouter(prefix="/iam", tags=["IAM"])
 
@@ -476,7 +478,22 @@ async def remove_user(
                 status_code=400,
                 detail="Cannot remove the last admin from the organization"
             )
-    
+
+    remove_user_org_workspace_memberships(
+        db,
+        organization_id=organization_id,
+        user_id=user_id,
+    )
+    credential = get_credential(
+        db, user_id=user_id, organization_id=organization_id
+    )
+    if credential is not None:
+        bump_org_session_epoch(credential)
+    revoke_refresh_tokens_for_user_org(
+        db,
+        user_id=user_id,
+        organization_id=organization_id,
+    )
     db.delete(member)
     db.commit()
     return None

--- a/app/api/v1/routes/llm_gateway.py
+++ b/app/api/v1/routes/llm_gateway.py
@@ -7,6 +7,8 @@ from fastapi import APIRouter, Depends
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
+from app.config import settings
+from app.core.auth.rbac import require_admin
 from app.dependencies import get_db, get_organization_id
 from app.services.ai.llm_gateway_settings import (
     GatewayInterfaceOverride,
@@ -87,6 +89,7 @@ def update_llm_gateway_settings(
     body: LLMGatewaySettingsUpdate,
     organization_id: UUID = Depends(get_organization_id),
     db: Session = Depends(get_db),
+    _admin: None = Depends(require_admin),
 ):
     result = set_org_settings(
         organization_id,

--- a/app/api/v1/routes/metrics.py
+++ b/app/api/v1/routes/metrics.py
@@ -13,6 +13,8 @@ from loguru import logger
 
 from app.database import get_db
 from app.dependencies import get_organization_id, get_api_key, get_workspace_id
+from app.core.api_rate_limit import enforce_resource_create_rate_limit
+from app.core.auth import Principal
 from app.services.billing.flexprice_service import record_metrics_llm_assist
 from app.models.database import Metric, MetricCategory, MetricType, MetricTrigger, ModelProvider
 from app.models.schemas import (
@@ -220,6 +222,7 @@ def create_metric(
     organization_id: UUID = Depends(get_organization_id),
     workspace_id: UUID = Depends(get_workspace_id),
     db: Session = Depends(get_db),
+    _principal: Principal = Depends(enforce_resource_create_rate_limit),
 ):
     """Create a new metric.
 

--- a/app/api/v1/routes/observability.py
+++ b/app/api/v1/routes/observability.py
@@ -584,6 +584,14 @@ async def stream_observability_call_audio(
     call_data = call_recording.call_data if isinstance(call_recording.call_data, dict) else {}
     recording_url = call_data.get("recording_url")
     if recording_url:
+        from app.services.telephony.exotel_client import ExotelInvalidContentError
+        from app.services.telephony.recording_download import assert_recording_url_safe
+
+        try:
+            assert_recording_url_safe(str(recording_url), user_supplied=True)
+        except ExotelInvalidContentError as exc:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
         return RedirectResponse(recording_url)
 
     s3_key = call_data.get("recording_s3_key")

--- a/app/api/v1/routes/personas.py
+++ b/app/api/v1/routes/personas.py
@@ -13,6 +13,8 @@ from pydantic import BaseModel
 from loguru import logger
 
 from app.dependencies import get_db, get_organization_id, get_workspace_id, get_api_key, require_enterprise_entitlement
+from app.core.api_rate_limit import enforce_resource_create_rate_limit
+from app.core.auth import Principal
 from app.models.database import (
     Persona, Evaluator, EvaluatorResult, TestAgentConversation, CustomTTSVoice,
     PromptOptimizationRun, CallRecording, Agent, AmbientNoiseAsset,
@@ -302,7 +304,8 @@ async def create_persona(
     persona: PersonaCreate,
     organization_id: UUID = Depends(get_organization_id),
     workspace_id: UUID = Depends(get_workspace_id),
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
+    _principal: Principal = Depends(enforce_resource_create_rate_limit),
 ):
     """Create a new persona stamped with the active workspace."""
     try:

--- a/app/api/v1/routes/platform_admin.py
+++ b/app/api/v1/routes/platform_admin.py
@@ -19,8 +19,12 @@ from app.core.auth.platform_admin import (
     platform_admin_feature_enabled,
     revoke_platform_access_token,
 )
-from app.core.auth.refresh_tokens import revoke_all_user_refresh_tokens
-from app.core.auth.session_epoch import bump_user_session_epoch
+from app.core.auth.refresh_tokens import revoke_refresh_tokens_for_user_org
+from app.core.auth.org_credentials import (
+    bump_org_session_epoch,
+    get_or_create_credential,
+    set_org_password_hash,
+)
 from app.core.password import hash_password, validate_password_strength, verify_password
 from app.database import get_db
 from app.models.database import (
@@ -353,9 +357,19 @@ def platform_reset_user_password(
         )
 
     _validate_password_or_400(payload.new_password)
-    user.password_hash = hash_password(payload.new_password)
-    bump_user_session_epoch(user)
-    revoke_all_user_refresh_tokens(db, user_id=user.id)
+    credential = get_or_create_credential(
+        db,
+        user_id=user.id,
+        organization_id=org_id,
+        user=user,
+    )
+    set_org_password_hash(credential, hash_password(payload.new_password))
+    bump_org_session_epoch(credential)
+    revoke_refresh_tokens_for_user_org(
+        db,
+        user_id=user.id,
+        organization_id=org_id,
+    )
     db.commit()
 
     return PlatformPasswordResetResponse(user_id=str(user.id), email=user.email)

--- a/app/api/v1/routes/platform_admin.py
+++ b/app/api/v1/routes/platform_admin.py
@@ -19,7 +19,10 @@ from app.core.auth.platform_admin import (
     platform_admin_feature_enabled,
     revoke_platform_access_token,
 )
-from app.core.auth.refresh_tokens import revoke_refresh_tokens_for_user_org
+from app.core.auth.refresh_tokens import (
+    revoke_refresh_tokens_for_user_org,
+    strip_org_from_user_refresh_auth,
+)
 from app.core.auth.org_credentials import (
     bump_org_session_epoch,
     get_or_create_credential,
@@ -365,6 +368,11 @@ def platform_reset_user_password(
     )
     set_org_password_hash(credential, hash_password(payload.new_password))
     bump_org_session_epoch(credential)
+    strip_org_from_user_refresh_auth(
+        db,
+        user_id=user.id,
+        organization_id=org_id,
+    )
     revoke_refresh_tokens_for_user_org(
         db,
         user_id=user.id,

--- a/app/api/v1/routes/platform_admin.py
+++ b/app/api/v1/routes/platform_admin.py
@@ -20,6 +20,7 @@ from app.core.auth.platform_admin import (
     revoke_platform_access_token,
 )
 from app.core.auth.refresh_tokens import revoke_all_user_refresh_tokens
+from app.core.auth.session_epoch import bump_user_session_epoch
 from app.core.password import hash_password, validate_password_strength, verify_password
 from app.database import get_db
 from app.models.database import (
@@ -353,6 +354,7 @@ def platform_reset_user_password(
 
     _validate_password_or_400(payload.new_password)
     user.password_hash = hash_password(payload.new_password)
+    bump_user_session_epoch(user)
     revoke_all_user_refresh_tokens(db, user_id=user.id)
     db.commit()
 

--- a/app/api/v1/routes/platform_admin.py
+++ b/app/api/v1/routes/platform_admin.py
@@ -6,12 +6,18 @@ from datetime import datetime, timezone
 from typing import List, Optional
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Query, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, Response, status
 from jose import JWTError
 from pydantic import BaseModel, EmailStr, Field
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
+from app.core.auth.cookies import (
+    clear_platform_session_cookies,
+    cookie_session_enabled,
+    read_platform_access_cookie,
+    set_platform_session_cookies,
+)
 from app.core.auth.platform_admin import (
     PlatformAdminPrincipal,
     create_platform_access_token,
@@ -158,7 +164,11 @@ def _serialize_signup_code(row: SignupReferenceCode, *, include_code: bool = Fal
 
 
 @router.post("/auth/login", response_model=PlatformTokenResponse)
-def platform_login(payload: PlatformLoginRequest, db: Session = Depends(get_db)) -> PlatformTokenResponse:
+def platform_login(
+    payload: PlatformLoginRequest,
+    response: Response,
+    db: Session = Depends(get_db),
+) -> PlatformTokenResponse:
     if not platform_admin_feature_enabled(db):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
 
@@ -180,10 +190,22 @@ def platform_login(payload: PlatformLoginRequest, db: Session = Depends(get_db))
         platform_admin_id=admin.id,
         email=admin.email,
     )
+    admin_summary = PlatformAdminSummary(id=str(admin.id), email=admin.email)
+    if cookie_session_enabled():
+        set_platform_session_cookies(
+            response,
+            access_token=access_token,
+            access_ttl_seconds=expires_in,
+        )
+        return PlatformTokenResponse(
+            access_token="",
+            expires_in=expires_in,
+            admin=admin_summary,
+        )
     return PlatformTokenResponse(
         access_token=access_token,
         expires_in=expires_in,
-        admin=PlatformAdminSummary(id=str(admin.id), email=admin.email),
+        admin=admin_summary,
     )
 
 
@@ -205,12 +227,16 @@ def _extract_bearer(authorization: Optional[str]) -> Optional[str]:
 
 @router.post("/auth/logout")
 def platform_logout(
+    request: Request,
+    response: Response,
     authorization: Optional[str] = Header(None, alias="Authorization"),
     principal: PlatformAdminPrincipal = Depends(get_platform_admin),
 ) -> dict:
-    bearer = _extract_bearer(authorization)
+    bearer = _extract_bearer(authorization) or read_platform_access_cookie(request)
     if bearer:
         revoke_platform_access_token(bearer)
+    if cookie_session_enabled():
+        clear_platform_session_cookies(response)
     return {"success": True, "admin_id": str(principal.platform_admin_id)}
 
 

--- a/app/api/v1/routes/playground.py
+++ b/app/api/v1/routes/playground.py
@@ -314,6 +314,11 @@ class CallRecordingUpdate(BaseModel):
     provider_call_id: str
 
 
+class CallRecordingRefresh(BaseModel):
+    """Optional provider call id when refreshing right after a web SDK call ends."""
+    provider_call_id: Optional[str] = None
+
+
 @router.put("/call-recordings/{call_short_id}", response_model=Dict[str, Any])
 async def update_call_recording(
     call_short_id: str,
@@ -957,6 +962,7 @@ async def get_call_recording(
 async def refresh_call_recording(
     call_short_id: str,
     background_tasks: BackgroundTasks,
+    refresh_data: Optional[CallRecordingRefresh] = Body(None),
     organization_id: UUID = Depends(get_organization_id),
     workspace_id: UUID = Depends(get_workspace_id),
     api_key: str = Depends(get_api_key),
@@ -977,6 +983,11 @@ async def refresh_call_recording(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Call recording not found"
         )
+
+    if refresh_data and refresh_data.provider_call_id:
+        call_recording.provider_call_id = refresh_data.provider_call_id
+        db.commit()
+        db.refresh(call_recording)
     
     if not call_recording.provider_call_id or not call_recording.provider_platform:
         raise HTTPException(

--- a/app/api/v1/routes/playground.py
+++ b/app/api/v1/routes/playground.py
@@ -41,6 +41,18 @@ from app.utils.call_recordings import generate_unique_call_short_id
 from app.services.evaluators.call_data_transcript import extract_transcript_from_call_data
 
 router = APIRouter(prefix="/playground", tags=["playground"])
+
+
+def _validate_playground_audio_url(url: str) -> None:
+    from app.services.telephony.exotel_client import ExotelInvalidContentError
+    from app.services.telephony.recording_download import assert_safe_provider_recording_url
+
+    try:
+        assert_safe_provider_recording_url(str(url))
+    except ExotelInvalidContentError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+
 def generate_unique_result_id(db: Session) -> str:
     """Generate a unique 6-digit result ID for EvaluatorResult."""
     max_attempts = 100
@@ -1311,6 +1323,7 @@ async def stream_call_audio(
         )
         if not url:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No recording URL available")
+        _validate_playground_audio_url(url)
         from fastapi.responses import RedirectResponse
         return RedirectResponse(url)
 
@@ -1319,6 +1332,7 @@ async def stream_call_audio(
         audio_url = recording_urls.get("conversation_audio")
         if not audio_url:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No recording URL available")
+        _validate_playground_audio_url(audio_url)
 
         agent = db.query(Agent).filter(Agent.id == call_recording.agent_id).first()
         if not agent or not agent.voice_ai_integration_id:

--- a/app/api/v1/routes/playground.py
+++ b/app/api/v1/routes/playground.py
@@ -112,7 +112,8 @@ def _validate_provider_call_id_for_recording(
         )
 
     try:
-        provider = get_voice_provider(platform, decrypted_api_key)
+        provider_class = get_voice_provider(platform)
+        provider = provider_class(api_key=decrypted_api_key)
         metrics = provider.retrieve_call_metrics(proposed_id)
     except Exception as exc:
         raise HTTPException(

--- a/app/api/v1/routes/playground.py
+++ b/app/api/v1/routes/playground.py
@@ -53,6 +53,81 @@ def _validate_playground_audio_url(url: str) -> None:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
 
 
+def _provider_agent_id_from_metrics(platform: str, metrics: Dict[str, Any]) -> Optional[str]:
+    platform_key = (platform or "").lower()
+    if platform_key == "vapi":
+        assistant = metrics.get("assistant")
+        return (
+            metrics.get("assistantId")
+            or metrics.get("assistant_id")
+            or (assistant.get("id") if isinstance(assistant, dict) else None)
+        )
+    if platform_key == "elevenlabs":
+        metadata = metrics.get("metadata")
+        return metrics.get("agent_id") or (
+            metadata.get("agent_id") if isinstance(metadata, dict) else None
+        )
+    return metrics.get("agent_id") or metrics.get("agentId") or metrics.get("assistant_id")
+
+
+def _validate_provider_call_id_for_recording(
+    call_recording: CallRecording,
+    proposed_id: str,
+    agent: Agent,
+    decrypted_api_key: str,
+) -> None:
+    """Ensure a client-supplied provider call id belongs to this recording's agent."""
+    proposed_id = (proposed_id or "").strip()
+    if not proposed_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="provider_call_id is required",
+        )
+
+    existing = (call_recording.provider_call_id or "").strip()
+    if existing:
+        if existing == proposed_id:
+            return
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="provider_call_id is already set and cannot be changed",
+        )
+
+    call_data = call_recording.call_data if isinstance(call_recording.call_data, dict) else {}
+    bound_call_id = call_data.get("call_id")
+    if bound_call_id and str(bound_call_id).strip():
+        if str(bound_call_id).strip() != proposed_id:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="provider_call_id does not match the call created for this recording",
+            )
+        return
+
+    platform = str(call_recording.provider_platform or "")
+    expected_agent_id = (agent.voice_ai_agent_id or "").strip()
+    if not expected_agent_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Agent has no voice provider agent id",
+        )
+
+    try:
+        provider = get_voice_provider(platform, decrypted_api_key)
+        metrics = provider.retrieve_call_metrics(proposed_id)
+    except Exception as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Could not verify provider call id: {exc}",
+        ) from exc
+
+    actual_agent_id = _provider_agent_id_from_metrics(platform, metrics)
+    if not actual_agent_id or str(actual_agent_id).strip() != expected_agent_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="provider_call_id is not associated with this recording's agent",
+        )
+
+
 def generate_unique_result_id(db: Session) -> str:
     """Generate a unique 6-digit result ID for EvaluatorResult."""
     max_attempts = 100
@@ -344,23 +419,47 @@ async def update_call_recording(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Call recording not found"
         )
-    
+
+    agent = db.query(Agent).filter(Agent.id == call_recording.agent_id).first()
+    if not agent or not agent.voice_ai_integration_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Agent or integration not found",
+        )
+    integration = db.query(Integration).filter(
+        Integration.id == agent.voice_ai_integration_id,
+        Integration.organization_id == organization_id,
+    ).first()
+    if not integration:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Integration not found",
+        )
+
+    try:
+        decrypted_api_key = decrypt_api_key(integration.api_key)
+    except Exception as exc:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to decrypt integration API key: {exc}",
+        ) from exc
+
+    _validate_provider_call_id_for_recording(
+        call_recording,
+        update_data.provider_call_id,
+        agent,
+        decrypted_api_key,
+    )
+
     call_recording.provider_call_id = update_data.provider_call_id
     db.commit()
     db.refresh(call_recording)
     
     # Trigger polling if we have all info
     if call_recording.provider_platform:
-        # Get integration api key
-        agent = db.query(Agent).filter(Agent.id == call_recording.agent_id).first()
         if agent and agent.voice_ai_integration_id:
-            integration = db.query(Integration).filter(
-                Integration.id == agent.voice_ai_integration_id
-            ).first()
-            
             if integration:
                 try:
-                    decrypted_api_key = decrypt_api_key(integration.api_key)
                     platform_key = (call_recording.provider_platform or "").lower()
                     # Vapi polls on call-end refresh only; update fires mid-call too.
                     if platform_key != "vapi":
@@ -984,25 +1083,22 @@ async def refresh_call_recording(
             detail="Call recording not found"
         )
 
-    if refresh_data and refresh_data.provider_call_id:
-        call_recording.provider_call_id = refresh_data.provider_call_id
-        db.commit()
-        db.refresh(call_recording)
-    
-    if not call_recording.provider_call_id or not call_recording.provider_platform:
+    if (
+        not (refresh_data and refresh_data.provider_call_id)
+        and (not call_recording.provider_call_id or not call_recording.provider_platform)
+    ):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Call recording does not have provider information"
+            detail="Call recording does not have provider information",
         )
-    
-    # Get the integration to get the API key
+
     agent = db.query(Agent).filter(Agent.id == call_recording.agent_id).first()
     if not agent or not agent.voice_ai_integration_id:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Agent or integration not found"
         )
-    
+
     integration = db.query(Integration).filter(
         Integration.id == agent.voice_ai_integration_id,
         Integration.organization_id == organization_id
@@ -1014,9 +1110,6 @@ async def refresh_call_recording(
             detail="Integration not found"
         )
 
-    if call_recording.evaluator_result_id:
-        return {"message": "Call recording already processed"}
-
     try:
         decrypted_api_key = decrypt_api_key(integration.api_key)
     except Exception as e:
@@ -1024,7 +1117,18 @@ async def refresh_call_recording(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to decrypt API key: {str(e)}"
         )
-    
+
+    if refresh_data and refresh_data.provider_call_id:
+        _validate_provider_call_id_for_recording(
+            call_recording,
+            refresh_data.provider_call_id,
+            agent,
+            decrypted_api_key,
+        )
+        call_recording.provider_call_id = refresh_data.provider_call_id
+        db.commit()
+        db.refresh(call_recording)
+
     # Start background task to poll for call metrics
     background_tasks.add_task(
         poll_call_metrics,

--- a/app/api/v1/routes/profile.py
+++ b/app/api/v1/routes/profile.py
@@ -268,6 +268,7 @@ async def get_my_invitations(
 @router.post("/invitations/{invitation_id}/accept", response_model=MessageResponse, operation_id="acceptInvitation")
 async def accept_invitation(
     invitation_id: UUID,
+    principal: Principal = Depends(get_principal),
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db)
 ):
@@ -283,7 +284,12 @@ async def accept_invitation(
         raise HTTPException(status_code=404, detail="Invitation not found")
 
     try:
-        accept_invitation_record(db, invitation, current_user)
+        accept_invitation_record(
+            db,
+            invitation,
+            current_user,
+            source_organization_id=principal.organization_id,
+        )
     except InvitationError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
 

--- a/app/api/v1/routes/profile.py
+++ b/app/api/v1/routes/profile.py
@@ -23,10 +23,16 @@ from app.core.password import hash_password
 from app.services.invitation_service import (
     InvitationError,
     accept_invitation as accept_invitation_record,
+    build_invite_join_notice,
     to_aware_utc,
 )
 
 router = APIRouter(prefix="/profile", tags=["Profile"])
+
+
+class InvitationAcceptResponse(BaseModel):
+    message: str
+    join_notice: Optional[str] = None
 
 
 # Preferences schemas
@@ -265,7 +271,11 @@ async def get_my_invitations(
     return result
 
 
-@router.post("/invitations/{invitation_id}/accept", response_model=MessageResponse, operation_id="acceptInvitation")
+@router.post(
+    "/invitations/{invitation_id}/accept",
+    response_model=InvitationAcceptResponse,
+    operation_id="acceptInvitation",
+)
 async def accept_invitation(
     invitation_id: UUID,
     principal: Principal = Depends(get_principal),
@@ -293,7 +303,27 @@ async def accept_invitation(
     except InvitationError as exc:
         raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
 
-    return {"message": "Invitation accepted successfully"}
+    org = (
+        db.query(Organization)
+        .filter(Organization.id == invitation.organization_id)
+        .first()
+    )
+    org_name = org.name if org else "the organization"
+    source_org_id = principal.organization_id
+    if source_org_id == invitation.organization_id:
+        source_org_id = None
+    join_notice = build_invite_join_notice(
+        db,
+        user=current_user,
+        organization_id=invitation.organization_id,
+        organization_name=org_name,
+        source_organization_id=source_org_id,
+    )
+
+    return InvitationAcceptResponse(
+        message="Invitation accepted successfully",
+        join_notice=join_notice,
+    )
 
 
 @router.post("/invitations/{invitation_id}/decline", response_model=MessageResponse, operation_id="declineInvitation")

--- a/app/api/v1/routes/profile.py
+++ b/app/api/v1/routes/profile.py
@@ -190,20 +190,7 @@ async def update_profile(
     
     if profile_update.last_name is not None:
         current_user.last_name = profile_update.last_name
-    
-    if profile_update.email is not None:
-        # Check if email is already taken
-        existing_user = db.query(User).filter(
-            User.email == profile_update.email,
-            User.id != current_user.id
-        ).first()
-        if existing_user:
-            raise HTTPException(
-                status_code=400,
-                detail="Email is already in use"
-            )
-        current_user.email = profile_update.email
-    
+
     db.commit()
     db.refresh(current_user)
     

--- a/app/api/v1/routes/scenarios.py
+++ b/app/api/v1/routes/scenarios.py
@@ -9,6 +9,8 @@ from typing import List, Optional
 from uuid import UUID
 
 from app.dependencies import get_db, get_organization_id, get_workspace_id
+from app.core.api_rate_limit import enforce_resource_create_rate_limit
+from app.core.auth import Principal
 from app.models.database import Scenario, Agent, Evaluator, EvaluatorResult, TestAgentConversation
 from app.models.schemas import (
     ScenarioCreate, ScenarioUpdate, ScenarioResponse
@@ -22,7 +24,8 @@ async def create_scenario(
     scenario: ScenarioCreate,
     organization_id: UUID = Depends(get_organization_id),
     workspace_id: UUID = Depends(get_workspace_id),
-    db: Session = Depends(get_db)
+    db: Session = Depends(get_db),
+    _principal: Principal = Depends(enforce_resource_create_rate_limit),
 ):
     """Create a new scenario stamped with the active workspace."""
     if scenario.agent_id is not None:

--- a/app/api/v1/routes/voice_agent.py
+++ b/app/api/v1/routes/voice_agent.py
@@ -789,19 +789,17 @@ async def bot_connect(
 
     Accepts either a Bearer access token (email/password / SSO login) or an
     API key (legacy / machine access). Credentials may be supplied via the
-    `Authorization` header, `X-API-Key` header, cookies (`access_token` /
-    `api_key`), or query parameters (`token` / `X-API-Key` / `api_key`).
+    `Authorization` header, `X-API-Key` header, cookies (`eai_access` /
+    `access_token` / `api_key`), or query parameters (`token` / `X-API-Key` /
+    `api_key`).
 
     Supports both GET and POST requests for compatibility with different client
     implementations. Pipecat's `startBotAndConnect` issues an HTTP request to
     this endpoint; the WebSocket URL returned here embeds the same credential
     so the subsequent /ws connection can authenticate without re-prompting.
     """
-    from app.core.auth.providers import (
-        AuthError,
-        RawCredential,
-        get_provider_registry,
-    )
+    from app.core.auth.dependency import resolve_request_credentials
+    from app.core.auth.providers import AuthError, get_provider_registry
 
     print("=" * 80)
     print(f"[BACKEND] /connect endpoint called at {__import__('datetime').datetime.now()}")
@@ -810,30 +808,14 @@ async def bot_connect(
     print(f"[BACKEND] Request cookies present: {list(request.cookies.keys())}")
     print(f"[BACKEND] Query params: {dict(request.query_params)}")
 
-    def _extract_bearer(value: Optional[str]) -> Optional[str]:
-        if not value:
-            return None
-        scheme, _, token = value.partition(" ")
-        if scheme.lower() != "bearer" or not token.strip():
-            return None
-        return token.strip()
-
-    # Bearer / access token: header, query param, then cookie.
-    bearer_token = (
-        _extract_bearer(request.headers.get("Authorization"))
-        or request.query_params.get("token")
-        or request.query_params.get("access_token")
-        or request.cookies.get("access_token")
+    cred = resolve_request_credentials(
+        authorization=request.headers.get("Authorization"),
+        x_api_key=request.headers.get("X-API-Key"),
+        x_eai_api_key=request.headers.get("X-EFFICIENTAI-API-KEY"),
+        request=request,
     )
-
-    # API key: header, query param, then cookie.
-    api_key = (
-        request.headers.get("X-API-Key")
-        or request.headers.get("X-EFFICIENTAI-API-KEY")
-        or request.query_params.get("X-API-Key")
-        or request.query_params.get("api_key")
-        or request.cookies.get("api_key")
-    )
+    bearer_token = cred.bearer_token
+    api_key = cred.api_key
 
     print(
         f"[BACKEND] Bearer token: {'found' if bearer_token else 'not found'}, "
@@ -852,7 +834,6 @@ async def bot_connect(
             ),
         )
 
-    cred = RawCredential(bearer_token=bearer_token, api_key=api_key)
     registry = get_provider_registry()
     provider = registry.find(cred)
     if provider is None:

--- a/app/api/v1/routes/voice_agent.py
+++ b/app/api/v1/routes/voice_agent.py
@@ -35,36 +35,21 @@ async def websocket_endpoint(
     """
     WebSocket endpoint for voice agent connection.
 
-    Authentication precedence (since browsers can't set custom headers on
-    WebSockets reliably, everything goes on query params):
+    Authentication precedence (query params and cookies; browsers cannot set
+    custom headers on WebSockets reliably):
 
-        1. ?token=<bearer>      -> local-password / SSO session token
-        2. ?X-API-Key=<key>     -> API key (legacy header name)
-        3. ?api_key=<key>       -> API key
+        1. ?token=<bearer> / ?access_token=<bearer> / eai_access cookie
+        2. ?X-API-Key=<key> / ?api_key=<key> / api_key cookie
 
     Under the hood we reuse the same pluggable auth registry used by the
     HTTP routes so the authorization rules stay consistent.
     """
-    from app.core.auth.providers import AuthError, RawCredential, get_provider_registry
+    from app.core.auth.dependency import resolve_websocket_credentials
+    from app.core.auth.providers import AuthError, get_provider_registry
 
-    bearer_token = (
-        websocket.query_params.get("token")
-        or websocket.query_params.get("access_token")
-    )
-    api_key = (
-        websocket.query_params.get("X-API-Key")
-        or websocket.query_params.get("api_key")
-    )
-
-    if not bearer_token and not api_key:
-        from urllib.parse import parse_qs
-
-        raw_qs = websocket.scope.get("query_string", b"")
-        if isinstance(raw_qs, bytes):
-            raw_qs = raw_qs.decode("utf-8", errors="replace")
-        parsed = parse_qs(raw_qs)
-        bearer_token = bearer_token or (parsed.get("token") or parsed.get("access_token") or [None])[0]
-        api_key = api_key or (parsed.get("X-API-Key") or parsed.get("api_key") or [None])[0]
+    cred = resolve_websocket_credentials(websocket)
+    bearer_token = cred.bearer_token
+    api_key = cred.api_key
 
     if not bearer_token and not api_key:
         print(
@@ -81,7 +66,6 @@ async def websocket_endpoint(
     try:
         db = next(get_db())
 
-        cred = RawCredential(bearer_token=bearer_token, api_key=api_key)
         registry = get_provider_registry()
         provider = registry.find(cred)
         if provider is None:
@@ -764,18 +748,23 @@ async def websocket_endpoint(
 
 
 @router.options("/connect")
-async def bot_connect_options():
+async def bot_connect_options(request: Request):
     """Handle CORS preflight requests."""
     from fastapi.responses import Response
-    return Response(
-        status_code=200,
-        headers={
-            "Access-Control-Allow-Origin": "*",
-            "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
-            "Access-Control-Allow-Headers": "*",
-            "Access-Control-Allow-Credentials": "true",
-        }
-    )
+
+    from app.config import settings
+
+    headers = {
+        "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+        "Access-Control-Allow-Headers": "*",
+    }
+    origin = request.headers.get("origin")
+    if origin and origin in settings.CORS_ORIGINS:
+        headers["Access-Control-Allow-Origin"] = origin
+        headers["Access-Control-Allow-Credentials"] = "true"
+    else:
+        headers["Access-Control-Allow-Origin"] = "*"
+    return Response(status_code=200, headers=headers)
 
 @router.post("/connect", response_model=Dict[str, Any])
 @router.get("/connect", response_model=Dict[str, Any])

--- a/app/api/v1/routes/voice_agent.py
+++ b/app/api/v1/routes/voice_agent.py
@@ -982,16 +982,52 @@ async def bot_connect(
     # Determine WebSocket URL — prefer dedicated media server when configured.
     from urllib.parse import quote
 
-    from app.services.media_urls import build_voice_agent_ws_url
+    from jose import JWTError
 
-    # Only embed secrets in the URL when the client supplied them explicitly
-    # (header/query). Cookie sessions authenticate the WebSocket via httpOnly cookies.
+    from app.core.auth.tokens import create_access_token, decode_access_token
+    from app.services.media_urls import (
+        build_voice_agent_ws_url,
+        cross_host_voice_ws,
+        resolve_voice_agent_ws_base,
+    )
+
+    fallback_host = request.headers.get("host", f"localhost:{settings.PORT}")
+    fallback_scheme = (
+        request.headers.get("x-forwarded-proto")
+        or getattr(request.url, "scheme", "http")
+        or "http"
+    )
+    ws_base = resolve_voice_agent_ws_base(
+        fallback_host=fallback_host,
+        fallback_scheme=fallback_scheme,
+    )
+    ws_cross_host = cross_host_voice_ws(ws_base, request)
+
+    # Same-host cookie sessions: WebSocket auth via httpOnly cookies (no URL secret).
+    # Cross-host media: cookies are not sent; use explicit creds or a 2-minute handshake token.
+    ws_auth_query: Optional[str] = None
     if bearer_token and resolved.bearer_source in ("header", "query"):
         ws_auth_query = f"token={quote(bearer_token, safe='')}"
     elif api_key and resolved.api_key_source in ("header", "query"):
         ws_auth_query = f"X-API-Key={quote(api_key, safe='')}"
-    else:
-        ws_auth_query = None
+    elif ws_cross_host:
+        if bearer_token and resolved.bearer_source == "cookie" and principal.user_id:
+            try:
+                claims = decode_access_token(bearer_token)
+            except JWTError:
+                claims = {}
+            handshake_token, _, _ = create_access_token(
+                user_id=principal.user_id,
+                organization_id=principal.organization_id,
+                email=principal.email or claims.get("email") or "",
+                session_epoch=int(claims.get("session_epoch", 0) or 0),
+                authenticated_org_ids=claims.get("authenticated_org_ids"),
+                authenticated_org_epochs=claims.get("authenticated_org_epochs"),
+                expires_in_minutes=2,
+            )
+            ws_auth_query = f"token={quote(handshake_token, safe='')}"
+        elif api_key and resolved.api_key_source == "cookie":
+            ws_auth_query = f"X-API-Key={quote(api_key, safe='')}"
 
     ws_url = build_voice_agent_ws_url(
         auth_query=ws_auth_query,
@@ -1000,12 +1036,8 @@ async def bot_connect(
         scenario_id=scenario_id,
         run_evaluation=run_evaluation,
         ui_surface=ui_surface,
-        fallback_host=request.headers.get("host", f"localhost:{settings.PORT}"),
-        fallback_scheme=(
-            request.headers.get("x-forwarded-proto")
-            or getattr(request.url, "scheme", "http")
-            or "http"
-        ),
+        fallback_host=fallback_host,
+        fallback_scheme=fallback_scheme,
     )
     
     # Return the response in the format Pipecat expects

--- a/app/api/v1/routes/voice_agent.py
+++ b/app/api/v1/routes/voice_agent.py
@@ -787,7 +787,7 @@ async def bot_connect(
     this endpoint; the WebSocket URL returned here embeds the same credential
     so the subsequent /ws connection can authenticate without re-prompting.
     """
-    from app.core.auth.dependency import resolve_request_credentials
+    from app.core.auth.dependency import resolve_request_credentials_with_sources
     from app.core.auth.providers import AuthError, get_provider_registry
 
     print("=" * 80)
@@ -797,12 +797,13 @@ async def bot_connect(
     print(f"[BACKEND] Request cookies present: {list(request.cookies.keys())}")
     print(f"[BACKEND] Query params: {dict(request.query_params)}")
 
-    cred = resolve_request_credentials(
+    resolved = resolve_request_credentials_with_sources(
         authorization=request.headers.get("Authorization"),
         x_api_key=request.headers.get("X-API-Key"),
         x_eai_api_key=request.headers.get("X-EFFICIENTAI-API-KEY"),
         request=request,
     )
+    cred = resolved.credential
     bearer_token = cred.bearer_token
     api_key = cred.api_key
 
@@ -983,10 +984,14 @@ async def bot_connect(
 
     from app.services.media_urls import build_voice_agent_ws_url
 
-    if bearer_token:
+    # Only embed secrets in the URL when the client supplied them explicitly
+    # (header/query). Cookie sessions authenticate the WebSocket via httpOnly cookies.
+    if bearer_token and resolved.bearer_source in ("header", "query"):
         ws_auth_query = f"token={quote(bearer_token, safe='')}"
+    elif api_key and resolved.api_key_source in ("header", "query"):
+        ws_auth_query = f"X-API-Key={quote(api_key, safe='')}"
     else:
-        ws_auth_query = f"X-API-Key={quote(api_key or '', safe='')}"
+        ws_auth_query = None
 
     ws_url = build_voice_agent_ws_url(
         auth_query=ws_auth_query,
@@ -1010,7 +1015,7 @@ async def bot_connect(
     response_data = {
         "ws_url": ws_url
     }
-    print(f"[BACKEND] ✅ Returning WebSocket URL: {ws_url}")
+    print(f"[BACKEND] ✅ Returning WebSocket URL (auth_in_url={ws_auth_query is not None})")
     print(f"[BACKEND] Response data: {response_data}")
     print("=" * 80)
     

--- a/app/app_factory.py
+++ b/app/app_factory.py
@@ -159,6 +159,7 @@ def _mount_frontend(app: FastAPI) -> None:
             or full_path.startswith("redoc")
             or full_path.startswith("assets/")
             or full_path == "health"
+            or full_path == "health/ready"
             or full_path == "health/detail"
             or full_path == "metrics"
         ):
@@ -236,11 +237,20 @@ def create_app() -> FastAPI:
 
     @app.get("/health")
     async def health_check(request: Request):
+        """Liveness probe for load balancers — process is up, no DB work."""
         check_health_rate_limit(request)
-        if is_operational_access_allowed(request):
-            payload, status_code = build_readiness_status(detailed=False)
-        else:
-            payload, status_code = build_liveness_status()
+        payload, status_code = build_liveness_status()
+        return JSONResponse(content=payload, status_code=status_code)
+
+    @app.get("/health/ready")
+    async def health_ready(request: Request):
+        """Readiness probe (VPC/LB only): migrations must be current."""
+        if not is_operational_access_allowed(request):
+            return JSONResponse(status_code=404, content={"detail": "Not found"})
+        payload, status_code = build_readiness_status(detailed=False)
+        if status_code != 200:
+            detail_payload, _ = build_readiness_status(detailed=True)
+            logger.warning("Readiness check failed on /health/ready: %s", detail_payload)
         return JSONResponse(content=payload, status_code=status_code)
 
     if _includes_http_routes():

--- a/app/app_factory.py
+++ b/app/app_factory.py
@@ -83,9 +83,10 @@ async def _api_lifespan(app: FastAPI):
 
         is_up_to_date, pending = check_migrations_status()
         if not is_up_to_date:
-            logger.warning("Warning: %d migration(s) still pending: %s", len(pending), ", ".join(pending))
-        else:
-            logger.info("All migrations are up to date")
+            detail = ", ".join(pending)
+            logger.error("CRITICAL: %d migration/schema issue(s) remain: %s", len(pending), detail)
+            raise RuntimeError(f"Database migrations incomplete: {detail}")
+        logger.info("All migrations are up to date")
 
         from app.services.billing.flexprice_service import log_startup_status
 

--- a/app/app_factory.py
+++ b/app/app_factory.py
@@ -6,14 +6,16 @@ import logging
 from contextlib import asynccontextmanager
 from pathlib import Path
 
-from fastapi import Depends, FastAPI
+from fastapi import Depends, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 
 from app.config import settings, validate_auth_configuration
 from app.core.auth.rbac import require_admin
-from app.core.health import build_health_status
+from app.core.api_rate_limit import check_health_rate_limit
+from app.core.health import build_liveness_status, build_readiness_status
+from app.core.operational_access_middleware import is_operational_access_allowed
 from app.core.migration_middleware import MigrationCheckMiddleware
 from app.core.migrations import check_migrations_status, ensure_migrations_directory, run_migrations
 from app.core.operational_access_middleware import OperationalAccessMiddleware
@@ -106,9 +108,9 @@ def _add_common_middleware(app: FastAPI) -> None:
 
     trusted_hosts = [h.strip() for h in (settings.TRUSTED_HOSTS or []) if h and h.strip()]
     if trusted_hosts:
-        from starlette.middleware.trustedhost import TrustedHostMiddleware
+        from app.core.trusted_host_middleware import SelectiveTrustedHostMiddleware
 
-        app.add_middleware(TrustedHostMiddleware, allowed_hosts=trusted_hosts)
+        app.add_middleware(SelectiveTrustedHostMiddleware, allowed_hosts=trusted_hosts)
 
     if settings.OBSERVABILITY_ENABLED and settings.LOKI_ENABLED and settings.LOKI_MULTI_TENANT:
         from app.core.observability_middleware import OrgLoggingMiddleware
@@ -233,8 +235,12 @@ def create_app() -> FastAPI:
             )
 
     @app.get("/health")
-    async def health_check():
-        payload, status_code = build_health_status(detailed=False)
+    async def health_check(request: Request):
+        check_health_rate_limit(request)
+        if is_operational_access_allowed(request):
+            payload, status_code = build_readiness_status(detailed=False)
+        else:
+            payload, status_code = build_liveness_status()
         return JSONResponse(content=payload, status_code=status_code)
 
     if _includes_http_routes():
@@ -244,7 +250,7 @@ def create_app() -> FastAPI:
             from app.database import SessionLocal
             from app.services.observability.catalog_storage_stats import collect_catalog_storage_stats
 
-            payload, status_code = build_health_status(detailed=True)
+            payload, status_code = build_readiness_status(detailed=True)
             db = SessionLocal()
             try:
                 payload["catalog_storage"] = collect_catalog_storage_stats(db)

--- a/app/app_factory.py
+++ b/app/app_factory.py
@@ -98,8 +98,17 @@ async def _api_lifespan(app: FastAPI):
 def _add_common_middleware(app: FastAPI) -> None:
     if _includes_http_routes():
         app.add_middleware(MigrationCheckMiddleware)
+        from app.core.csrf_middleware import CsrfMiddleware
+
+        app.add_middleware(CsrfMiddleware)
         app.add_middleware(ReaderReadOnlyMiddleware)
         app.add_middleware(LLMUsageContextMiddleware)
+
+    trusted_hosts = [h.strip() for h in (settings.TRUSTED_HOSTS or []) if h and h.strip()]
+    if trusted_hosts:
+        from starlette.middleware.trustedhost import TrustedHostMiddleware
+
+        app.add_middleware(TrustedHostMiddleware, allowed_hosts=trusted_hosts)
 
     if settings.OBSERVABILITY_ENABLED and settings.LOKI_ENABLED and settings.LOKI_MULTI_TENANT:
         from app.core.observability_middleware import OrgLoggingMiddleware

--- a/app/config.py
+++ b/app/config.py
@@ -188,6 +188,8 @@ class Settings(BaseSettings):
     # Operational endpoints (/health, /metrics)
     OPERATIONAL_PUBLIC: bool = False
     OPERATIONAL_TRUSTED_IPS: List[str] = []
+    HEALTH_RATE_LIMIT_PER_MINUTE: int = 60
+    HEALTH_READINESS_CACHE_SECONDS: int = 10
 
     # SMTP / Email Notifications (for Alerts)
     SMTP_HOST: Optional[str] = None  # e.g., "smtp.gmail.com"
@@ -943,6 +945,14 @@ def load_config_from_file(config_path: str) -> None:
             settings.OPERATIONAL_PUBLIC = bool(operational_config["public"])
         if "trusted_ips" in operational_config:
             settings.OPERATIONAL_TRUSTED_IPS = operational_config["trusted_ips"]
+        if "health_rate_limit_per_minute" in operational_config:
+            settings.HEALTH_RATE_LIMIT_PER_MINUTE = int(
+                operational_config["health_rate_limit_per_minute"]
+            )
+        if "health_readiness_cache_seconds" in operational_config:
+            settings.HEALTH_READINESS_CACHE_SECONDS = int(
+                operational_config["health_readiness_cache_seconds"]
+            )
 
     if "security" in config_data:
         security_config = config_data["security"]

--- a/app/config.py
+++ b/app/config.py
@@ -244,14 +244,9 @@ class Settings(BaseSettings):
     PLIVO_OUTBOUND_POOL: List[str] = []
     EXOTEL_OUTBOUND_POOL: List[str] = []
 
-    # Recording URL fetch safety (SSRF guards for CSV/direct-URL imports)
-    RECORDING_URL_ALLOWED_HOST_SUFFIXES: List[str] = [
-        "exotel.com",
-        "plivo.com",
-        "vobiz.ai",
-        "amazonaws.com",
-        "cloudfront.net",
-    ]
+    # Extra recording URL host suffixes merged onto built-in provider allowlist.
+    # Leave empty to use defaults only (see recording_download.py).
+    RECORDING_URL_ALLOWED_HOST_SUFFIXES: List[str] = []
 
     # Live telephony pipeline recording merge (dual-track → natural mono)
     # Residual one-way carrier latency trim applied to the bot track at merge time.
@@ -892,6 +887,10 @@ def load_config_from_file(config_path: str) -> None:
         if telephony_cfg.get("outbound_pool_max_concurrent_per_org") is not None:
             settings.TELEPHONY_OUTBOUND_POOL_MAX_CONCURRENT_PER_ORG = int(
                 telephony_cfg["outbound_pool_max_concurrent_per_org"]
+            )
+        if telephony_cfg.get("recording_url_allowed_host_suffixes"):
+            settings.RECORDING_URL_ALLOWED_HOST_SUFFIXES = list(
+                telephony_cfg["recording_url_allowed_host_suffixes"]
             )
 
     if "judge_alignment" in config_data:

--- a/app/config.py
+++ b/app/config.py
@@ -428,16 +428,18 @@ class Settings(BaseSettings):
             self.CELERY_RESULT_BACKEND = self.REDIS_URL
 
 
+_PLACEHOLDER_SECRETS = frozenset({
+    "your-secret-key-here-change-in-production",
+    "changeme",
+    "change-me",
+    "secret",
+})
+
+
 def validate_auth_configuration() -> None:
     """Fail fast when auth or session signing is misconfigured."""
     from app.core.license import has_auth_feature
 
-    _PLACEHOLDER_SECRETS = {
-        "your-secret-key-here-change-in-production",
-        "changeme",
-        "change-me",
-        "secret",
-    }
     secret = (settings.SECRET_KEY or "").strip()
     if not settings.DEBUG and (
         not secret
@@ -510,7 +512,16 @@ def load_config_from_file(config_path: str) -> None:
         if "debug" in app_config:
             settings.DEBUG = app_config["debug"]
         if "secret_key" in app_config:
-            settings.SECRET_KEY = app_config["secret_key"]
+            yaml_secret = str(_expand_env_ref(app_config["secret_key"]) or "").strip()
+            env_secret = (os.environ.get("SECRET_KEY") or "").strip()
+            if (
+                not yaml_secret
+                or len(yaml_secret) < 32
+                or yaml_secret.lower() in _PLACEHOLDER_SECRETS
+            ) and env_secret:
+                settings.SECRET_KEY = env_secret
+            elif yaml_secret:
+                settings.SECRET_KEY = yaml_secret
         if "frontend_base_url" in app_config:
             settings.FRONTEND_BASE_URL = app_config["frontend_base_url"]
         server_config = config_data["server"]

--- a/app/config.py
+++ b/app/config.py
@@ -107,6 +107,19 @@ class Settings(BaseSettings):
     # API Settings
     API_KEY_HEADER: str = "X-API-Key"
     RATE_LIMIT_PER_MINUTE: int = 60
+    API_RATE_LIMIT_ENFORCE: bool = True
+    API_AUTH_RATE_LIMIT_PER_MINUTE: int = 15
+    API_RESOURCE_CREATE_BURST: int = 100
+    API_RESOURCE_CREATE_BURST_WINDOW_MINUTES: int = 10
+    API_RESOURCE_CREATE_SUSTAINED_PER_MINUTE: int = 30
+    API_RESOURCE_CREATE_ORG_PER_HOUR: int = 2000
+
+    # HTTP security
+    PUBLIC_BASE_URL: str = ""
+    TRUSTED_HOSTS: Annotated[List[str], NoDecode] = []
+    SECURITY_HSTS_ENABLED: bool = False
+    SECURITY_HSTS_MAX_AGE: int = 31536000
+    SECURITY_HSTS_INCLUDE_SUBDOMAINS: bool = True
 
     # Authentication
     AUTH_PROVIDERS: Annotated[List[str], NoDecode] = ["api_key"]
@@ -114,6 +127,10 @@ class Settings(BaseSettings):
     AUTH_GATED_SIGNUP_ENABLED: bool = False
     AUTH_LOCAL_TOKEN_TTL_MINUTES: int = 15
     AUTH_REFRESH_TOKEN_TTL_DAYS: int = 7
+    AUTH_COOKIE_SESSION_ENABLED: bool = True
+    AUTH_COOKIE_SECURE: Optional[bool] = None
+    AUTH_COOKIE_SAMESITE: str = "lax"
+    AUTH_COOKIE_DOMAIN: Optional[str] = None
     AUTH_OIDC_ISSUER: Optional[str] = None
     AUTH_OIDC_CLIENT_ID: Optional[str] = None
     AUTH_OIDC_AUDIENCE: Optional[str] = None
@@ -417,8 +434,25 @@ class Settings(BaseSettings):
 
 
 def validate_auth_configuration() -> None:
-    """Fail fast when external OIDC is licensed and enabled but misconfigured."""
+    """Fail fast when auth or session signing is misconfigured."""
     from app.core.license import has_auth_feature
+
+    _PLACEHOLDER_SECRETS = {
+        "your-secret-key-here-change-in-production",
+        "changeme",
+        "change-me",
+        "secret",
+    }
+    secret = (settings.SECRET_KEY or "").strip()
+    if not settings.DEBUG and (
+        not secret
+        or len(secret) < 32
+        or secret.lower() in _PLACEHOLDER_SECRETS
+    ):
+        raise RuntimeError(
+            "SECRET_KEY must be set to a random string of at least 32 characters "
+            "in non-debug deployments."
+        )
 
     providers = {p.strip().lower() for p in (settings.AUTH_PROVIDERS or [])}
     if "external_oidc" not in providers:
@@ -738,6 +772,16 @@ def load_config_from_file(config_path: str) -> None:
                 settings.AUTH_LOCAL_TOKEN_TTL_MINUTES = int(local_config["token_ttl_minutes"])
             if "refresh_token_ttl_days" in local_config:
                 settings.AUTH_REFRESH_TOKEN_TTL_DAYS = int(local_config["refresh_token_ttl_days"])
+            cookie_config = local_config.get("cookie_session", {})
+            if isinstance(cookie_config, dict):
+                if "enabled" in cookie_config:
+                    settings.AUTH_COOKIE_SESSION_ENABLED = bool(cookie_config["enabled"])
+                if "secure" in cookie_config:
+                    settings.AUTH_COOKIE_SECURE = bool(cookie_config["secure"])
+                if "samesite" in cookie_config:
+                    settings.AUTH_COOKIE_SAMESITE = str(cookie_config["samesite"])
+                if "domain" in cookie_config:
+                    settings.AUTH_COOKIE_DOMAIN = cookie_config["domain"] or None
             gated_config = local_config.get("gated_signup", {})
             if isinstance(gated_config, dict) and "enabled" in gated_config:
                 settings.AUTH_GATED_SIGNUP_ENABLED = bool(gated_config["enabled"])
@@ -898,6 +942,39 @@ def load_config_from_file(config_path: str) -> None:
             settings.CSP_REPORT_ONLY = bool(security_config["csp_report_only"])
         if security_config.get("csp_policy"):
             settings.CSP_POLICY = security_config["csp_policy"]
+        if security_config.get("public_base_url"):
+            settings.PUBLIC_BASE_URL = str(security_config["public_base_url"]).strip()
+        if "trusted_hosts" in security_config:
+            settings.TRUSTED_HOSTS = list(security_config["trusted_hosts"])
+        if "hsts_enabled" in security_config:
+            settings.SECURITY_HSTS_ENABLED = bool(security_config["hsts_enabled"])
+        if "hsts_max_age" in security_config:
+            settings.SECURITY_HSTS_MAX_AGE = int(security_config["hsts_max_age"])
+        if "hsts_include_subdomains" in security_config:
+            settings.SECURITY_HSTS_INCLUDE_SUBDOMAINS = bool(
+                security_config["hsts_include_subdomains"]
+            )
+
+    if "rate_limits" in config_data:
+        rate_cfg = config_data["rate_limits"]
+        if "enforce" in rate_cfg:
+            settings.API_RATE_LIMIT_ENFORCE = bool(rate_cfg["enforce"])
+        if "auth_per_ip_per_minute" in rate_cfg:
+            settings.API_AUTH_RATE_LIMIT_PER_MINUTE = int(rate_cfg["auth_per_ip_per_minute"])
+        if "resource_create_burst" in rate_cfg:
+            settings.API_RESOURCE_CREATE_BURST = int(rate_cfg["resource_create_burst"])
+        if "resource_create_burst_window_minutes" in rate_cfg:
+            settings.API_RESOURCE_CREATE_BURST_WINDOW_MINUTES = int(
+                rate_cfg["resource_create_burst_window_minutes"]
+            )
+        if "resource_create_sustained_per_minute" in rate_cfg:
+            settings.API_RESOURCE_CREATE_SUSTAINED_PER_MINUTE = int(
+                rate_cfg["resource_create_sustained_per_minute"]
+            )
+        if "resource_create_org_per_hour" in rate_cfg:
+            settings.API_RESOURCE_CREATE_ORG_PER_HOUR = int(
+                rate_cfg["resource_create_org_per_hour"]
+            )
 
     if "flexprice" in config_data:
         flexprice_config = config_data["flexprice"]

--- a/app/core/api_rate_limit.py
+++ b/app/core/api_rate_limit.py
@@ -1,0 +1,102 @@
+"""Abuse-only API rate limits (auth strict, resource creates generous)."""
+
+from __future__ import annotations
+
+import time
+from typing import Callable, Optional
+from uuid import UUID
+
+import redis
+from fastapi import Depends, HTTPException, Request, status
+
+from app.config import settings
+from app.core.auth import Principal, get_principal
+
+_redis_client: Optional[redis.Redis] = None
+_KEY_PREFIX = "api:rate"
+
+
+def _get_redis() -> redis.Redis:
+    global _redis_client
+    if _redis_client is None:
+        _redis_client = redis.from_url(settings.REDIS_URL, decode_responses=True)
+    return _redis_client
+
+
+def _client_ip(request: Request) -> str:
+    forwarded = request.headers.get("x-forwarded-for")
+    if forwarded:
+        return forwarded.split(",")[0].strip()
+    if request.client and request.client.host:
+        return request.client.host
+    return "unknown"
+
+
+def _sliding_window_count(key: str, window_seconds: int) -> int:
+    now = int(time.time())
+    pipe = _get_redis().pipeline()
+    pipe.zremrangebyscore(key, 0, now - window_seconds)
+    pipe.zadd(key, {f"{now}:{time.time_ns()}": now})
+    pipe.zcard(key)
+    pipe.expire(key, window_seconds + 5)
+    _, _, count, _ = pipe.execute()
+    return int(count or 0)
+
+
+def _check_limit(key: str, limit: int, window_seconds: int) -> None:
+    if limit <= 0:
+        return
+    try:
+        count = _sliding_window_count(key, window_seconds)
+    except redis.RedisError:
+        return
+    if count > limit:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Rate limit exceeded",
+            headers={"Retry-After": str(window_seconds)},
+        )
+
+
+def check_auth_rate_limit(request: Request) -> None:
+    if not settings.API_RATE_LIMIT_ENFORCE:
+        return
+    ip = _client_ip(request)
+    limit = max(1, int(settings.API_AUTH_RATE_LIMIT_PER_MINUTE))
+    _check_limit(f"{_KEY_PREFIX}:auth:ip:{ip}", limit, 60)
+
+
+def check_resource_create_rate_limit(principal: Principal) -> None:
+    if not settings.API_RATE_LIMIT_ENFORCE:
+        return
+    burst_limit = max(1, int(settings.API_RESOURCE_CREATE_BURST))
+    burst_window = max(1, int(settings.API_RESOURCE_CREATE_BURST_WINDOW_MINUTES)) * 60
+    sustained_limit = max(1, int(settings.API_RESOURCE_CREATE_SUSTAINED_PER_MINUTE))
+    org_limit = max(1, int(settings.API_RESOURCE_CREATE_ORG_PER_HOUR))
+
+    if principal.user_id:
+        user_key = f"{_KEY_PREFIX}:create:user:{principal.user_id}"
+        _check_limit(user_key, burst_limit, burst_window)
+        _check_limit(f"{user_key}:min", sustained_limit, 60)
+    elif principal.api_key_id:
+        key = f"{_KEY_PREFIX}:create:api_key:{principal.api_key_id}"
+        _check_limit(key, burst_limit, burst_window)
+        _check_limit(f"{key}:min", sustained_limit, 60)
+
+    org_key = f"{_KEY_PREFIX}:create:org:{principal.organization_id}"
+    _check_limit(org_key, org_limit, 3600)
+
+
+def enforce_auth_rate_limit(request: Request) -> None:
+    check_auth_rate_limit(request)
+
+
+def enforce_resource_create_rate_limit(
+    principal: Principal = Depends(get_principal),
+) -> Principal:
+    check_resource_create_rate_limit(principal)
+    return principal
+
+
+def resource_create_limiter() -> Callable:
+    return Depends(enforce_resource_create_rate_limit)

--- a/app/core/api_rate_limit.py
+++ b/app/core/api_rate_limit.py
@@ -11,6 +11,7 @@ from fastapi import Depends, HTTPException, Request, status
 
 from app.config import settings
 from app.core.auth import Principal, get_principal
+from app.core.operational_access_middleware import _resolved_trusted_ip
 
 _redis_client: Optional[redis.Redis] = None
 _KEY_PREFIX = "api:rate"
@@ -24,9 +25,9 @@ def _get_redis() -> redis.Redis:
 
 
 def _client_ip(request: Request) -> str:
-    forwarded = request.headers.get("x-forwarded-for")
-    if forwarded:
-        return forwarded.split(",")[0].strip()
+    resolved = _resolved_trusted_ip(request)
+    if resolved:
+        return resolved
     if request.client and request.client.host:
         return request.client.host
     return "unknown"

--- a/app/core/api_rate_limit.py
+++ b/app/core/api_rate_limit.py
@@ -11,7 +11,10 @@ from fastapi import Depends, HTTPException, Request, status
 
 from app.config import settings
 from app.core.auth import Principal, get_principal
-from app.core.operational_access_middleware import _resolved_trusted_ip
+from app.core.operational_access_middleware import (
+    _resolved_trusted_ip,
+    is_operational_access_allowed,
+)
 
 _redis_client: Optional[redis.Redis] = None
 _KEY_PREFIX = "api:rate"
@@ -65,6 +68,19 @@ def check_auth_rate_limit(request: Request) -> None:
     ip = _client_ip(request)
     limit = max(1, int(settings.API_AUTH_RATE_LIMIT_PER_MINUTE))
     _check_limit(f"{_KEY_PREFIX}:auth:ip:{ip}", limit, 60)
+
+
+def check_health_rate_limit(request: Request) -> None:
+    """Rate-limit anonymous /health abuse; LB/VPC peers in operational.trusted_ips are exempt."""
+    if not settings.API_RATE_LIMIT_ENFORCE:
+        return
+    if is_operational_access_allowed(request):
+        return
+    limit = int(settings.HEALTH_RATE_LIMIT_PER_MINUTE)
+    if limit <= 0:
+        return
+    ip = _client_ip(request)
+    _check_limit(f"{_KEY_PREFIX}:health:ip:{ip}", max(1, limit), 60)
 
 
 def check_resource_create_rate_limit(principal: Principal) -> None:

--- a/app/core/auth/__init__.py
+++ b/app/core/auth/__init__.py
@@ -25,6 +25,7 @@ from app.core.auth.dependency import (
     get_principal,
     get_optional_principal,
     get_user_principal,
+    resolve_request_credentials,
 )
 
 __all__ = [
@@ -36,4 +37,5 @@ __all__ = [
     "get_principal",
     "get_optional_principal",
     "get_user_principal",
+    "resolve_request_credentials",
 ]

--- a/app/core/auth/cookies.py
+++ b/app/core/auth/cookies.py
@@ -1,0 +1,123 @@
+"""httpOnly session cookies for browser auth (Phase B)."""
+
+from __future__ import annotations
+
+import secrets
+from typing import Optional
+
+from starlette.requests import Request
+from starlette.responses import Response
+
+from app.config import settings
+
+COOKIE_ACCESS = "eai_access"
+COOKIE_REFRESH = "eai_refresh"
+COOKIE_CSRF = "eai_csrf"
+LEGACY_ACCESS_COOKIE = "access_token"
+CSRF_HEADER = "X-CSRF-Token"
+
+
+def cookie_session_enabled() -> bool:
+    return bool(getattr(settings, "AUTH_COOKIE_SESSION_ENABLED", True))
+
+
+def _cookie_secure() -> bool:
+    configured = getattr(settings, "AUTH_COOKIE_SECURE", None)
+    if configured is not None:
+        return bool(configured)
+    return not settings.DEBUG
+
+
+def _cookie_samesite() -> str:
+    value = (getattr(settings, "AUTH_COOKIE_SAMESITE", None) or "lax").strip().lower()
+    if value not in {"lax", "strict", "none"}:
+        return "lax"
+    return value
+
+
+def _cookie_domain() -> Optional[str]:
+    domain = getattr(settings, "AUTH_COOKIE_DOMAIN", None)
+    if domain is None:
+        return None
+    stripped = str(domain).strip()
+    return stripped or None
+
+
+def _base_cookie_kwargs() -> dict:
+    kwargs = {
+        "httponly": True,
+        "secure": _cookie_secure(),
+        "samesite": _cookie_samesite(),
+        "path": "/",
+    }
+    domain = _cookie_domain()
+    if domain:
+        kwargs["domain"] = domain
+    return kwargs
+
+
+def read_access_cookie(request: Request) -> Optional[str]:
+    token = request.cookies.get(COOKIE_ACCESS) or request.cookies.get(LEGACY_ACCESS_COOKIE)
+    if token and token.strip():
+        return token.strip()
+    return None
+
+
+def read_refresh_cookie(request: Request) -> Optional[str]:
+    token = request.cookies.get(COOKIE_REFRESH)
+    if token and token.strip():
+        return token.strip()
+    return None
+
+
+def read_csrf_cookie(request: Request) -> Optional[str]:
+    token = request.cookies.get(COOKIE_CSRF)
+    if token and token.strip():
+        return token.strip()
+    return None
+
+
+def has_cookie_session(request: Request) -> bool:
+    return read_access_cookie(request) is not None
+
+
+def set_session_cookies(
+    response: Response,
+    *,
+    access_token: str,
+    refresh_token: Optional[str],
+    access_ttl_seconds: int,
+    refresh_ttl_seconds: int,
+) -> str:
+    """Set access, refresh, and CSRF cookies. Returns the CSRF token."""
+    csrf_token = secrets.token_urlsafe(32)
+    access_kwargs = {**_base_cookie_kwargs(), "max_age": max(1, int(access_ttl_seconds))}
+    response.set_cookie(COOKIE_ACCESS, access_token, **access_kwargs)
+    if refresh_token:
+        refresh_kwargs = {**_base_cookie_kwargs(), "max_age": max(1, int(refresh_ttl_seconds))}
+        response.set_cookie(COOKIE_REFRESH, refresh_token, **refresh_kwargs)
+    csrf_kwargs = {
+        "httponly": False,
+        "secure": _cookie_secure(),
+        "samesite": _cookie_samesite(),
+        "path": "/",
+        "max_age": max(1, int(refresh_ttl_seconds)),
+    }
+    domain = _cookie_domain()
+    if domain:
+        csrf_kwargs["domain"] = domain
+    response.set_cookie(COOKIE_CSRF, csrf_token, **csrf_kwargs)
+    return csrf_token
+
+
+def clear_session_cookies(response: Response) -> None:
+    clear_kwargs = {
+        "path": "/",
+        "secure": _cookie_secure(),
+        "samesite": _cookie_samesite(),
+    }
+    domain = _cookie_domain()
+    if domain:
+        clear_kwargs["domain"] = domain
+    for name in (COOKIE_ACCESS, COOKIE_REFRESH, COOKIE_CSRF, LEGACY_ACCESS_COOKIE):
+        response.delete_cookie(name, **clear_kwargs)

--- a/app/core/auth/cookies.py
+++ b/app/core/auth/cookies.py
@@ -13,6 +13,7 @@ from app.config import settings
 COOKIE_ACCESS = "eai_access"
 COOKIE_REFRESH = "eai_refresh"
 COOKIE_CSRF = "eai_csrf"
+COOKIE_PLATFORM_ACCESS = "eai_platform_access"
 LEGACY_ACCESS_COOKIE = "access_token"
 CSRF_HEADER = "X-CSRF-Token"
 
@@ -81,6 +82,17 @@ def has_cookie_session(request: Request) -> bool:
     return read_access_cookie(request) is not None
 
 
+def read_platform_access_cookie(request: Request) -> Optional[str]:
+    token = request.cookies.get(COOKIE_PLATFORM_ACCESS)
+    if token and token.strip():
+        return token.strip()
+    return None
+
+
+def has_platform_cookie_session(request: Request) -> bool:
+    return read_platform_access_cookie(request) is not None
+
+
 def set_session_cookies(
     response: Response,
     *,
@@ -121,3 +133,39 @@ def clear_session_cookies(response: Response) -> None:
         clear_kwargs["domain"] = domain
     for name in (COOKIE_ACCESS, COOKIE_REFRESH, COOKIE_CSRF, LEGACY_ACCESS_COOKIE):
         response.delete_cookie(name, **clear_kwargs)
+
+
+def set_platform_session_cookies(
+    response: Response,
+    *,
+    access_token: str,
+    access_ttl_seconds: int,
+) -> str:
+    """Set platform admin access + CSRF cookies. Returns the CSRF token."""
+    csrf_token = secrets.token_urlsafe(32)
+    access_kwargs = {**_base_cookie_kwargs(), "max_age": max(1, int(access_ttl_seconds))}
+    response.set_cookie(COOKIE_PLATFORM_ACCESS, access_token, **access_kwargs)
+    csrf_kwargs = {
+        "httponly": False,
+        "secure": _cookie_secure(),
+        "samesite": _cookie_samesite(),
+        "path": "/",
+        "max_age": max(1, int(access_ttl_seconds)),
+    }
+    domain = _cookie_domain()
+    if domain:
+        csrf_kwargs["domain"] = domain
+    response.set_cookie(COOKIE_CSRF, csrf_token, **csrf_kwargs)
+    return csrf_token
+
+
+def clear_platform_session_cookies(response: Response) -> None:
+    clear_kwargs = {
+        "path": "/",
+        "secure": _cookie_secure(),
+        "samesite": _cookie_samesite(),
+    }
+    domain = _cookie_domain()
+    if domain:
+        clear_kwargs["domain"] = domain
+    response.delete_cookie(COOKIE_PLATFORM_ACCESS, **clear_kwargs)

--- a/app/core/auth/dependency.py
+++ b/app/core/auth/dependency.py
@@ -16,6 +16,7 @@ Credential resolution order (first match wins):
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Optional
 
 from fastapi import Depends, Header, HTTPException, Request
@@ -35,6 +36,15 @@ def _extract_bearer(authorization: Optional[str]) -> Optional[str]:
     if scheme.lower() != "bearer" or not token.strip():
         return None
     return token.strip()
+
+
+@dataclass(frozen=True)
+class ResolvedCredentials:
+    """Credentials plus where each value was read from (for URL vs cookie WS auth)."""
+
+    credential: RawCredential
+    bearer_source: Optional[str] = None  # header | query | cookie
+    api_key_source: Optional[str] = None  # header | query | cookie
 
 
 def resolve_request_credentials(
@@ -63,6 +73,60 @@ def resolve_request_credentials(
         )
 
     return RawCredential(bearer_token=bearer_token, api_key=api_key)
+
+
+def resolve_request_credentials_with_sources(
+    *,
+    authorization: Optional[str] = None,
+    x_api_key: Optional[str] = None,
+    x_eai_api_key: Optional[str] = None,
+    request: Optional[Request] = None,
+) -> ResolvedCredentials:
+    """Resolve credentials and record whether each value came from header, query, or cookie."""
+    bearer_source: Optional[str] = None
+    api_key_source: Optional[str] = None
+
+    bearer_token = _extract_bearer(authorization)
+    if bearer_token:
+        bearer_source = "header"
+    api_key = x_api_key or x_eai_api_key or None
+    if api_key:
+        api_key_source = "header"
+
+    if request is not None:
+        if not bearer_token:
+            query_bearer = (
+                request.query_params.get("token")
+                or request.query_params.get("access_token")
+            )
+            if query_bearer:
+                bearer_token = query_bearer
+                bearer_source = "query"
+            else:
+                cookie_bearer = read_access_cookie(request)
+                if cookie_bearer:
+                    bearer_token = cookie_bearer
+                    bearer_source = "cookie"
+
+        if not api_key:
+            query_api_key = (
+                request.query_params.get("api_key")
+                or request.query_params.get("X-API-Key")
+            )
+            if query_api_key:
+                api_key = query_api_key
+                api_key_source = "query"
+            else:
+                cookie_api_key = request.cookies.get("api_key")
+                if cookie_api_key:
+                    api_key = cookie_api_key
+                    api_key_source = "cookie"
+
+    return ResolvedCredentials(
+        credential=RawCredential(bearer_token=bearer_token, api_key=api_key),
+        bearer_source=bearer_source,
+        api_key_source=api_key_source,
+    )
 
 
 def resolve_websocket_credentials(websocket: WebSocket) -> RawCredential:

--- a/app/core/auth/dependency.py
+++ b/app/core/auth/dependency.py
@@ -20,8 +20,9 @@ from typing import Optional
 
 from fastapi import Depends, Header, HTTPException, Request
 from sqlalchemy.orm import Session
+from starlette.websockets import WebSocket
 
-from app.core.auth.cookies import read_access_cookie
+from app.core.auth.cookies import COOKIE_ACCESS, LEGACY_ACCESS_COOKIE, read_access_cookie
 from app.core.auth.principal import Principal
 from app.core.auth.providers import AuthError, RawCredential, get_provider_registry
 from app.database import get_db
@@ -60,6 +61,38 @@ def resolve_request_credentials(
             or request.query_params.get("X-API-Key")
             or request.cookies.get("api_key")
         )
+
+    return RawCredential(bearer_token=bearer_token, api_key=api_key)
+
+
+def resolve_websocket_credentials(websocket: WebSocket) -> RawCredential:
+    """Collect bearer/API-key credentials from WebSocket query params and cookies."""
+    bearer_token = (
+        websocket.query_params.get("token")
+        or websocket.query_params.get("access_token")
+    )
+    api_key = (
+        websocket.query_params.get("X-API-Key")
+        or websocket.query_params.get("api_key")
+    )
+
+    if not bearer_token:
+        bearer_token = (
+            websocket.cookies.get(COOKIE_ACCESS)
+            or websocket.cookies.get(LEGACY_ACCESS_COOKIE)
+        )
+    if not api_key:
+        api_key = websocket.cookies.get("api_key")
+
+    if not bearer_token and not api_key:
+        from urllib.parse import parse_qs
+
+        raw_qs = websocket.scope.get("query_string", b"")
+        if isinstance(raw_qs, bytes):
+            raw_qs = raw_qs.decode("utf-8", errors="replace")
+        parsed = parse_qs(raw_qs)
+        bearer_token = bearer_token or (parsed.get("token") or parsed.get("access_token") or [None])[0]
+        api_key = api_key or (parsed.get("X-API-Key") or parsed.get("api_key") or [None])[0]
 
     return RawCredential(bearer_token=bearer_token, api_key=api_key)
 

--- a/app/core/auth/dependency.py
+++ b/app/core/auth/dependency.py
@@ -54,6 +54,7 @@ def _resolve(
         bearer_token = (
             bearer_token
             or query_bearer
+            or request.cookies.get("eai_access")
             or request.cookies.get("access_token")
         )
         query_api_key = (

--- a/app/core/auth/dependency.py
+++ b/app/core/auth/dependency.py
@@ -10,7 +10,7 @@ Credential resolution order (first match wins):
     2. `X-API-Key` header
     3. `X-EFFICIENTAI-API-KEY` header (legacy, for webhooks)
     4. `token` / `access_token` query param (SSE / EventSource / <audio> src)
-    5. `access_token` cookie (fallback when no explicit query token)
+    5. `eai_access` / `access_token` cookie (httpOnly browser sessions)
     6. `api_key` / `X-API-Key` query param, then cookie (SSE / EventSource)
 """
 
@@ -21,6 +21,7 @@ from typing import Optional
 from fastapi import Depends, Header, HTTPException, Request
 from sqlalchemy.orm import Session
 
+from app.core.auth.cookies import read_access_cookie
 from app.core.auth.principal import Principal
 from app.core.auth.providers import AuthError, RawCredential, get_provider_registry
 from app.database import get_db
@@ -35,6 +36,34 @@ def _extract_bearer(authorization: Optional[str]) -> Optional[str]:
     return token.strip()
 
 
+def resolve_request_credentials(
+    *,
+    authorization: Optional[str] = None,
+    x_api_key: Optional[str] = None,
+    x_eai_api_key: Optional[str] = None,
+    request: Optional[Request] = None,
+) -> RawCredential:
+    """Collect bearer/API-key credentials from headers, query params, and cookies."""
+    bearer_token = _extract_bearer(authorization)
+    api_key = x_api_key or x_eai_api_key or None
+
+    if request is not None:
+        bearer_token = (
+            bearer_token
+            or request.query_params.get("token")
+            or request.query_params.get("access_token")
+            or read_access_cookie(request)
+        )
+        api_key = (
+            api_key
+            or request.query_params.get("api_key")
+            or request.query_params.get("X-API-Key")
+            or request.cookies.get("api_key")
+        )
+
+    return RawCredential(bearer_token=bearer_token, api_key=api_key)
+
+
 def _resolve(
     authorization: Optional[str],
     x_api_key: Optional[str],
@@ -43,33 +72,11 @@ def _resolve(
     *,
     request: Optional[Request] = None,
 ) -> Optional[Principal]:
-    bearer_token = _extract_bearer(authorization)
-    api_key = x_api_key or x_eai_api_key or None
-
-    if request is not None:
-        query_bearer = (
-            request.query_params.get("token")
-            or request.query_params.get("access_token")
-        )
-        bearer_token = (
-            bearer_token
-            or query_bearer
-            or request.cookies.get("eai_access")
-            or request.cookies.get("access_token")
-        )
-        query_api_key = (
-            request.query_params.get("api_key")
-            or request.query_params.get("X-API-Key")
-        )
-        api_key = (
-            api_key
-            or query_api_key
-            or request.cookies.get("api_key")
-        )
-
-    cred = RawCredential(
-        bearer_token=bearer_token,
-        api_key=api_key,
+    cred = resolve_request_credentials(
+        authorization=authorization,
+        x_api_key=x_api_key,
+        x_eai_api_key=x_eai_api_key,
+        request=request,
     )
     if not cred.bearer_token and not cred.api_key:
         return None

--- a/app/core/auth/local.py
+++ b/app/core/auth/local.py
@@ -67,6 +67,11 @@ class LocalPasswordProvider(AuthProvider):
         if not user:
             raise AuthError("User no longer active")
 
+        token_epoch = int(claims.get("session_epoch", 0) or 0)
+        user_epoch = int(getattr(user, "session_epoch", 0) or 0)
+        if token_epoch != user_epoch:
+            raise AuthError("Session expired — please sign in again")
+
         member = (
             db.query(OrganizationMember)
             .filter(

--- a/app/core/auth/local.py
+++ b/app/core/auth/local.py
@@ -67,10 +67,7 @@ class LocalPasswordProvider(AuthProvider):
         if not user:
             raise AuthError("User no longer active")
 
-        token_epoch = int(claims.get("session_epoch", 0) or 0)
-        user_epoch = int(getattr(user, "session_epoch", 0) or 0)
-        if token_epoch != user_epoch:
-            raise AuthError("Session expired — please sign in again")
+        from app.core.auth.org_credentials import get_credential, resolve_session_epoch
 
         member = (
             db.query(OrganizationMember)
@@ -82,6 +79,12 @@ class LocalPasswordProvider(AuthProvider):
         )
         if not member:
             raise AuthError("User is not a member of this organization")
+
+        credential = get_credential(db, user_id=user_id, organization_id=org_id)
+        token_epoch = int(claims.get("session_epoch", 0) or 0)
+        user_epoch = resolve_session_epoch(credential, user)
+        if token_epoch != user_epoch:
+            raise AuthError("Session expired — please sign in again")
 
         ensure_organization_active(db, org_id)
 

--- a/app/core/auth/org_credentials.py
+++ b/app/core/auth/org_credentials.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Dict, List, Optional, Sequence, Tuple
 from uuid import UUID
 
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from app.core.password import verify_password
@@ -36,6 +37,64 @@ def get_session_revocation_floor(
     return int(row.min_session_epoch or 0)
 
 
+def _upsert_session_revocation_floor(
+    db: Session,
+    *,
+    user_id: UUID,
+    organization_id: UUID,
+    next_floor: int,
+) -> int:
+    dialect_name = db.get_bind().dialect.name
+    if dialect_name == "postgresql":
+        from sqlalchemy.dialects.postgresql import insert as dialect_insert
+    elif dialect_name == "sqlite":
+        from sqlalchemy.dialects.sqlite import insert as dialect_insert
+    else:
+        row = (
+            db.query(OrganizationMemberSessionRevocation)
+            .filter(
+                OrganizationMemberSessionRevocation.user_id == user_id,
+                OrganizationMemberSessionRevocation.organization_id == organization_id,
+            )
+            .first()
+        )
+        if row is None:
+            db.add(
+                OrganizationMemberSessionRevocation(
+                    organization_id=organization_id,
+                    user_id=user_id,
+                    min_session_epoch=next_floor,
+                )
+            )
+        else:
+            row.min_session_epoch = max(int(row.min_session_epoch or 0), next_floor)
+        db.flush()
+        return get_session_revocation_floor(
+            db, user_id=user_id, organization_id=organization_id
+        )
+
+    table = OrganizationMemberSessionRevocation.__table__
+    stmt = dialect_insert(table).values(
+        organization_id=organization_id,
+        user_id=user_id,
+        min_session_epoch=next_floor,
+    )
+    stmt = stmt.on_conflict_do_update(
+        index_elements=["organization_id", "user_id"],
+        set_={
+            "min_session_epoch": func.max(
+                table.c.min_session_epoch,
+                stmt.excluded.min_session_epoch,
+            )
+        },
+    )
+    db.execute(stmt)
+    db.flush()
+    return get_session_revocation_floor(
+        db, user_id=user_id, organization_id=organization_id
+    )
+
+
 def record_org_membership_session_revocation(
     db: Session,
     *,
@@ -52,26 +111,12 @@ def record_org_membership_session_revocation(
     else:
         next_floor = max(prior_floor + 1, 1) if prior_floor else 1
 
-    row = (
-        db.query(OrganizationMemberSessionRevocation)
-        .filter(
-            OrganizationMemberSessionRevocation.user_id == user_id,
-            OrganizationMemberSessionRevocation.organization_id == organization_id,
-        )
-        .first()
+    return _upsert_session_revocation_floor(
+        db,
+        user_id=user_id,
+        organization_id=organization_id,
+        next_floor=next_floor,
     )
-    if row is None:
-        db.add(
-            OrganizationMemberSessionRevocation(
-                organization_id=organization_id,
-                user_id=user_id,
-                min_session_epoch=next_floor,
-            )
-        )
-    else:
-        row.min_session_epoch = max(int(row.min_session_epoch or 0), next_floor)
-    db.flush()
-    return next_floor
 
 
 def revoke_org_membership_credential(

--- a/app/core/auth/org_credentials.py
+++ b/app/core/auth/org_credentials.py
@@ -172,7 +172,7 @@ def resolve_current_password_hash(
     user: User,
 ) -> Optional[str]:
     """Verify password rotations only — never used for login matching."""
-    if credential is not None and credential.password_hash:
+    if credential is not None:
         return credential.password_hash
     return user.password_hash
 

--- a/app/core/auth/org_credentials.py
+++ b/app/core/auth/org_credentials.py
@@ -8,19 +8,88 @@ from uuid import UUID
 from sqlalchemy.orm import Session
 
 from app.core.password import verify_password
-from app.models.database import Organization, OrganizationMember, OrganizationMemberCredential, User
+from app.models.database import (
+    Organization,
+    OrganizationMember,
+    OrganizationMemberCredential,
+    OrganizationMemberSessionRevocation,
+    User,
+)
 
 
-def delete_org_credential(
+def get_session_revocation_floor(
+    db: Session,
+    *,
+    user_id: UUID,
+    organization_id: UUID,
+) -> int:
+    row = (
+        db.query(OrganizationMemberSessionRevocation)
+        .filter(
+            OrganizationMemberSessionRevocation.user_id == user_id,
+            OrganizationMemberSessionRevocation.organization_id == organization_id,
+        )
+        .first()
+    )
+    if row is None:
+        return 0
+    return int(row.min_session_epoch or 0)
+
+
+def record_org_membership_session_revocation(
+    db: Session,
+    *,
+    user_id: UUID,
+    organization_id: UUID,
+    credential: Optional[OrganizationMemberCredential] = None,
+) -> int:
+    """Remember the next required session epoch after membership removal."""
+    prior_floor = get_session_revocation_floor(
+        db, user_id=user_id, organization_id=organization_id
+    )
+    if credential is not None:
+        next_floor = max(prior_floor, int(credential.session_epoch or 0) + 1)
+    else:
+        next_floor = max(prior_floor + 1, 1) if prior_floor else 1
+
+    row = (
+        db.query(OrganizationMemberSessionRevocation)
+        .filter(
+            OrganizationMemberSessionRevocation.user_id == user_id,
+            OrganizationMemberSessionRevocation.organization_id == organization_id,
+        )
+        .first()
+    )
+    if row is None:
+        db.add(
+            OrganizationMemberSessionRevocation(
+                organization_id=organization_id,
+                user_id=user_id,
+                min_session_epoch=next_floor,
+            )
+        )
+    else:
+        row.min_session_epoch = max(int(row.min_session_epoch or 0), next_floor)
+    db.flush()
+    return next_floor
+
+
+def revoke_org_membership_credential(
     db: Session,
     *,
     user_id: UUID,
     organization_id: UUID,
 ) -> bool:
-    row = get_credential(db, user_id=user_id, organization_id=organization_id)
-    if row is None:
+    credential = get_credential(db, user_id=user_id, organization_id=organization_id)
+    record_org_membership_session_revocation(
+        db,
+        user_id=user_id,
+        organization_id=organization_id,
+        credential=credential,
+    )
+    if credential is None:
         return False
-    db.delete(row)
+    db.delete(credential)
     db.flush()
     return True
 
@@ -139,12 +208,15 @@ def provision_membership_credential(
         if auth_provider is None and inherited_provider:
             auth_provider = inherited_provider
 
+    session_epoch = get_session_revocation_floor(
+        db, user_id=user_id, organization_id=organization_id
+    )
     row = OrganizationMemberCredential(
         organization_id=organization_id,
         user_id=user_id,
         password_hash=password_hash,
         auth_provider=auth_provider,
-        session_epoch=0,
+        session_epoch=session_epoch,
     )
     db.add(row)
     db.flush()

--- a/app/core/auth/org_credentials.py
+++ b/app/core/auth/org_credentials.py
@@ -41,7 +41,41 @@ def get_or_create_credential(
         db,
         user_id=user_id,
         organization_id=organization_id,
+        user=user,
     )
+
+
+def user_has_any_org_credentials(db: Session, user_id: UUID) -> bool:
+    return (
+        db.query(OrganizationMemberCredential.id)
+        .filter(OrganizationMemberCredential.user_id == user_id)
+        .first()
+        is not None
+    )
+
+
+def find_source_password_for_new_membership(
+    db: Session,
+    user_id: UUID,
+    *,
+    user: Optional[User] = None,
+) -> Tuple[Optional[str], Optional[str]]:
+    existing = (
+        db.query(OrganizationMemberCredential)
+        .filter(
+            OrganizationMemberCredential.user_id == user_id,
+            OrganizationMemberCredential.password_hash.isnot(None),
+        )
+        .order_by(OrganizationMemberCredential.created_at.asc())
+        .first()
+    )
+    if existing is not None:
+        return existing.password_hash, existing.auth_provider
+    if user is None:
+        user = db.query(User).filter(User.id == user_id).first()
+    if user is not None and user.password_hash:
+        return user.password_hash, user.auth_provider or "local"
+    return None, None
 
 
 def provision_membership_credential(
@@ -51,10 +85,20 @@ def provision_membership_credential(
     organization_id: UUID,
     password_hash: Optional[str] = None,
     auth_provider: Optional[str] = None,
+    user: Optional[User] = None,
 ) -> OrganizationMemberCredential:
     row = get_credential(db, user_id=user_id, organization_id=organization_id)
     if row is not None:
         return row
+
+    if password_hash is None:
+        inherited_hash, inherited_provider = find_source_password_for_new_membership(
+            db, user_id, user=user
+        )
+        if inherited_hash:
+            password_hash = inherited_hash
+        if auth_provider is None and inherited_provider:
+            auth_provider = inherited_provider
 
     row = OrganizationMemberCredential(
         organization_id=organization_id,
@@ -83,11 +127,18 @@ def user_has_any_local_password(db: Session, user: User) -> bool:
 
 
 def resolve_password_hash(
-    credential: Optional[OrganizationMemberCredential],
+    db: Session,
     user: User,
+    credential: Optional[OrganizationMemberCredential],
 ) -> Optional[str]:
     if credential is not None and credential.password_hash:
         return credential.password_hash
+    if (
+        credential is None
+        and not user_has_any_org_credentials(db, user.id)
+        and user.password_hash
+    ):
+        return user.password_hash
     return None
 
 
@@ -134,7 +185,7 @@ def org_has_password(
     organization_id: UUID,
 ) -> bool:
     credential = get_credential(db, user_id=user.id, organization_id=organization_id)
-    return bool(resolve_password_hash(credential, user))
+    return bool(resolve_password_hash(db, user, credential))
 
 
 def match_password_memberships(
@@ -161,7 +212,7 @@ def match_password_memberships(
 
     matched: List[Tuple[OrganizationMember, Organization]] = []
     for member, org, credential in rows:
-        password_hash = resolve_password_hash(credential, user)
+        password_hash = resolve_password_hash(db, user, credential)
         if password_hash and verify_password(password, password_hash):
             matched.append((member, org))
     return matched

--- a/app/core/auth/org_credentials.py
+++ b/app/core/auth/org_credentials.py
@@ -1,0 +1,132 @@
+"""Per-organization password and session epoch helpers."""
+
+from __future__ import annotations
+
+from typing import List, Optional, Sequence, Tuple
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.core.password import verify_password
+from app.models.database import Organization, OrganizationMember, OrganizationMemberCredential, User
+
+
+def get_credential(
+    db: Session,
+    *,
+    user_id: UUID,
+    organization_id: UUID,
+) -> Optional[OrganizationMemberCredential]:
+    return (
+        db.query(OrganizationMemberCredential)
+        .filter(
+            OrganizationMemberCredential.user_id == user_id,
+            OrganizationMemberCredential.organization_id == organization_id,
+        )
+        .first()
+    )
+
+
+def get_or_create_credential(
+    db: Session,
+    *,
+    user_id: UUID,
+    organization_id: UUID,
+    user: Optional[User] = None,
+) -> OrganizationMemberCredential:
+    row = get_credential(db, user_id=user_id, organization_id=organization_id)
+    if row is not None:
+        return row
+
+    if user is None:
+        user = db.query(User).filter(User.id == user_id).first()
+
+    row = OrganizationMemberCredential(
+        organization_id=organization_id,
+        user_id=user_id,
+        password_hash=user.password_hash if user is not None else None,
+        auth_provider=user.auth_provider if user is not None else None,
+        session_epoch=int(getattr(user, "session_epoch", 0) or 0) if user is not None else 0,
+    )
+    db.add(row)
+    db.flush()
+    return row
+
+
+def resolve_password_hash(
+    credential: Optional[OrganizationMemberCredential],
+    user: User,
+) -> Optional[str]:
+    if credential is not None and credential.password_hash:
+        return credential.password_hash
+    return user.password_hash
+
+
+def resolve_session_epoch(
+    credential: Optional[OrganizationMemberCredential],
+    user: User,
+) -> int:
+    if credential is not None:
+        return int(credential.session_epoch or 0)
+    return int(getattr(user, "session_epoch", 0) or 0)
+
+
+def bump_org_session_epoch(credential: OrganizationMemberCredential) -> int:
+    current = int(credential.session_epoch or 0)
+    credential.session_epoch = current + 1
+    return credential.session_epoch
+
+
+def set_org_password_hash(
+    credential: OrganizationMemberCredential,
+    password_hash: str,
+    *,
+    auth_provider: Optional[str] = "local",
+) -> None:
+    credential.password_hash = password_hash
+    if auth_provider and not credential.auth_provider:
+        credential.auth_provider = auth_provider
+
+
+def org_has_password(
+    db: Session,
+    *,
+    user: User,
+    organization_id: UUID,
+) -> bool:
+    credential = get_credential(db, user_id=user.id, organization_id=organization_id)
+    return bool(resolve_password_hash(credential, user))
+
+
+def match_password_memberships(
+    db: Session,
+    *,
+    user: User,
+    password: str,
+) -> List[Tuple[OrganizationMember, Organization]]:
+    rows = (
+        db.query(OrganizationMember, Organization, OrganizationMemberCredential)
+        .join(Organization, Organization.id == OrganizationMember.organization_id)
+        .outerjoin(
+            OrganizationMemberCredential,
+            (OrganizationMemberCredential.organization_id == OrganizationMember.organization_id)
+            & (OrganizationMemberCredential.user_id == OrganizationMember.user_id),
+        )
+        .filter(
+            OrganizationMember.user_id == user.id,
+            Organization.is_active == True,  # noqa: E712
+        )
+        .order_by(OrganizationMember.joined_at.asc())
+        .all()
+    )
+
+    matched: List[Tuple[OrganizationMember, Organization]] = []
+    for member, org, credential in rows:
+        password_hash = resolve_password_hash(credential, user)
+        if password_hash and verify_password(password, password_hash):
+            matched.append((member, org))
+    return matched
+
+
+def authenticated_org_id_strings(org_ids: Sequence[UUID]) -> List[str]:
+    return [str(org_id) for org_id in org_ids]

--- a/app/core/auth/org_credentials.py
+++ b/app/core/auth/org_credentials.py
@@ -2,13 +2,27 @@
 
 from __future__ import annotations
 
-from typing import List, Optional, Sequence, Tuple
+from typing import Dict, List, Optional, Sequence, Tuple
 from uuid import UUID
 
 from sqlalchemy.orm import Session
 
 from app.core.password import verify_password
 from app.models.database import Organization, OrganizationMember, OrganizationMemberCredential, User
+
+
+def delete_org_credential(
+    db: Session,
+    *,
+    user_id: UUID,
+    organization_id: UUID,
+) -> bool:
+    row = get_credential(db, user_id=user_id, organization_id=organization_id)
+    if row is None:
+        return False
+    db.delete(row)
+    db.flush()
+    return True
 
 
 def get_credential(
@@ -245,3 +259,37 @@ def match_password_memberships(
 
 def authenticated_org_id_strings(org_ids: Sequence[UUID]) -> List[str]:
     return [str(org_id) for org_id in org_ids]
+
+
+def build_authenticated_org_epochs(
+    db: Session,
+    user: User,
+    org_ids: Sequence[UUID],
+) -> Dict[str, int]:
+    epochs: Dict[str, int] = {}
+    for org_id in org_ids:
+        credential = get_credential(db, user_id=user.id, organization_id=org_id)
+        epochs[str(org_id)] = resolve_session_epoch(credential, user)
+    return epochs
+
+
+def filter_authenticated_orgs_by_epoch(
+    db: Session,
+    user: User,
+    org_ids: Sequence[UUID],
+    epochs: Optional[Dict[str, int]],
+) -> Tuple[List[UUID], Dict[str, int]]:
+    """Drop orgs whose stored password-auth epoch no longer matches the credential."""
+    valid_ids: List[UUID] = []
+    valid_epochs: Dict[str, int] = {}
+    for org_id in org_ids:
+        key = str(org_id)
+        stored_epoch = (epochs or {}).get(key)
+        if stored_epoch is None:
+            continue
+        credential = get_credential(db, user_id=user.id, organization_id=org_id)
+        if resolve_session_epoch(credential, user) != int(stored_epoch):
+            continue
+        valid_ids.append(org_id)
+        valid_epochs[key] = int(stored_epoch)
+    return valid_ids, valid_epochs

--- a/app/core/auth/org_credentials.py
+++ b/app/core/auth/org_credentials.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Dict, List, Optional, Sequence, Tuple
 from uuid import UUID
 
-from sqlalchemy import func
+from sqlalchemy import case
 from sqlalchemy.orm import Session
 
 from app.core.password import verify_password
@@ -82,9 +82,12 @@ def _upsert_session_revocation_floor(
     stmt = stmt.on_conflict_do_update(
         index_elements=["organization_id", "user_id"],
         set_={
-            "min_session_epoch": func.max(
-                table.c.min_session_epoch,
-                stmt.excluded.min_session_epoch,
+            "min_session_epoch": case(
+                (
+                    table.c.min_session_epoch > stmt.excluded.min_session_epoch,
+                    table.c.min_session_epoch,
+                ),
+                else_=stmt.excluded.min_session_epoch,
             )
         },
     )

--- a/app/core/auth/org_credentials.py
+++ b/app/core/auth/org_credentials.py
@@ -37,26 +37,65 @@ def get_or_create_credential(
     row = get_credential(db, user_id=user_id, organization_id=organization_id)
     if row is not None:
         return row
+    return provision_membership_credential(
+        db,
+        user_id=user_id,
+        organization_id=organization_id,
+    )
 
-    if user is None:
-        user = db.query(User).filter(User.id == user_id).first()
+
+def provision_membership_credential(
+    db: Session,
+    *,
+    user_id: UUID,
+    organization_id: UUID,
+    password_hash: Optional[str] = None,
+    auth_provider: Optional[str] = None,
+) -> OrganizationMemberCredential:
+    row = get_credential(db, user_id=user_id, organization_id=organization_id)
+    if row is not None:
+        return row
 
     row = OrganizationMemberCredential(
         organization_id=organization_id,
         user_id=user_id,
-        password_hash=user.password_hash if user is not None else None,
-        auth_provider=user.auth_provider if user is not None else None,
-        session_epoch=int(getattr(user, "session_epoch", 0) or 0) if user is not None else 0,
+        password_hash=password_hash,
+        auth_provider=auth_provider,
+        session_epoch=0,
     )
     db.add(row)
     db.flush()
     return row
 
 
+def user_has_any_local_password(db: Session, user: User) -> bool:
+    if user.password_hash:
+        return True
+    return (
+        db.query(OrganizationMemberCredential.id)
+        .filter(
+            OrganizationMemberCredential.user_id == user.id,
+            OrganizationMemberCredential.password_hash.isnot(None),
+        )
+        .first()
+        is not None
+    )
+
+
 def resolve_password_hash(
     credential: Optional[OrganizationMemberCredential],
     user: User,
 ) -> Optional[str]:
+    if credential is not None and credential.password_hash:
+        return credential.password_hash
+    return None
+
+
+def resolve_current_password_hash(
+    credential: Optional[OrganizationMemberCredential],
+    user: User,
+) -> Optional[str]:
+    """Verify password rotations only — never used for login matching."""
     if credential is not None and credential.password_hash:
         return credential.password_hash
     return user.password_hash

--- a/app/core/auth/org_credentials.py
+++ b/app/core/auth/org_credentials.py
@@ -59,22 +59,43 @@ def find_source_password_for_new_membership(
     user_id: UUID,
     *,
     user: Optional[User] = None,
+    source_organization_id: Optional[UUID] = None,
 ) -> Tuple[Optional[str], Optional[str]]:
-    existing = (
+    """Pick a password hash to seed a new membership credential.
+
+    When ``source_organization_id`` is provided (e.g. the org the user
+    authenticated into before accepting an invite), only that org's credential
+    is used. Otherwise inheritance happens only when every existing org
+    credential shares the same hash, or when no org credentials exist yet
+    (legacy ``users.password_hash`` backfill).
+    """
+    if source_organization_id is not None:
+        source = get_credential(
+            db, user_id=user_id, organization_id=source_organization_id
+        )
+        if source is not None and source.password_hash:
+            return source.password_hash, source.auth_provider
+        return None, None
+
+    creds_with_password = (
         db.query(OrganizationMemberCredential)
         .filter(
             OrganizationMemberCredential.user_id == user_id,
             OrganizationMemberCredential.password_hash.isnot(None),
         )
-        .order_by(OrganizationMemberCredential.created_at.asc())
-        .first()
+        .all()
     )
-    if existing is not None:
-        return existing.password_hash, existing.auth_provider
-    if user is None:
-        user = db.query(User).filter(User.id == user_id).first()
-    if user is not None and user.password_hash:
-        return user.password_hash, user.auth_provider or "local"
+    if not creds_with_password:
+        if user is None:
+            user = db.query(User).filter(User.id == user_id).first()
+        if user is not None and user.password_hash:
+            return user.password_hash, user.auth_provider or "local"
+        return None, None
+
+    distinct_hashes = {cred.password_hash for cred in creds_with_password}
+    if len(distinct_hashes) == 1:
+        first = creds_with_password[0]
+        return first.password_hash, first.auth_provider
     return None, None
 
 
@@ -86,6 +107,7 @@ def provision_membership_credential(
     password_hash: Optional[str] = None,
     auth_provider: Optional[str] = None,
     user: Optional[User] = None,
+    source_organization_id: Optional[UUID] = None,
 ) -> OrganizationMemberCredential:
     row = get_credential(db, user_id=user_id, organization_id=organization_id)
     if row is not None:
@@ -93,7 +115,10 @@ def provision_membership_credential(
 
     if password_hash is None:
         inherited_hash, inherited_provider = find_source_password_for_new_membership(
-            db, user_id, user=user
+            db,
+            user_id,
+            user=user,
+            source_organization_id=source_organization_id,
         )
         if inherited_hash:
             password_hash = inherited_hash

--- a/app/core/auth/platform_admin.py
+++ b/app/core/auth/platform_admin.py
@@ -7,11 +7,12 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, Optional, Tuple
 from uuid import UUID, uuid4
 
-from fastapi import Depends, Header, HTTPException, status
+from fastapi import Depends, Header, HTTPException, Request, status
 from jose import JWTError, jwt
 from sqlalchemy.orm import Session
 
 from app.config import settings
+from app.core.auth.cookies import read_platform_access_cookie
 from app.core.auth.token_revocation import is_access_jti_revoked, revoke_access_jti
 from app.database import get_db
 from app.models.database import PlatformAdmin
@@ -95,11 +96,12 @@ def require_platform_admin_feature(db: Session = Depends(get_db)) -> None:
 
 
 def get_platform_admin(
+    request: Request,
     authorization: Optional[str] = Header(None, alias="Authorization"),
     db: Session = Depends(get_db),
     _feature: None = Depends(require_platform_admin_feature),
 ) -> PlatformAdminPrincipal:
-    bearer = _extract_bearer(authorization)
+    bearer = _extract_bearer(authorization) or read_platform_access_cookie(request)
     if not bearer:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,

--- a/app/core/auth/refresh_tokens.py
+++ b/app/core/auth/refresh_tokens.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import hashlib
 import secrets
 from datetime import datetime, timedelta, timezone
-from typing import List, Optional, Sequence
+from typing import Dict, List, Optional, Sequence, Tuple
 from uuid import UUID
 
 from sqlalchemy.orm import Session
@@ -35,11 +35,13 @@ def issue_refresh_token(
     user_id: UUID,
     organization_id: UUID,
     authenticated_org_ids: Optional[Sequence[str]] = None,
+    authenticated_org_epochs: Optional[Dict[str, int]] = None,
 ) -> str:
     """Create a new refresh token row and return the raw token value."""
     raw = generate_refresh_token_value()
     expires_at = datetime.now(timezone.utc) + timedelta(days=settings.AUTH_REFRESH_TOKEN_TTL_DAYS)
     org_ids = list(authenticated_org_ids) if authenticated_org_ids else None
+    epochs = dict(authenticated_org_epochs) if authenticated_org_epochs else None
     db.add(
         RefreshToken(
             user_id=user_id,
@@ -47,13 +49,14 @@ def issue_refresh_token(
             token_hash=_hash_token(raw),
             expires_at=expires_at,
             authenticated_org_ids=org_ids,
+            authenticated_org_epochs=epochs,
         )
     )
     db.flush()
     return raw
 
 
-def authenticated_org_ids_from_refresh_row(row: RefreshToken) -> Optional[List[UUID]]:
+def _org_ids_from_refresh_row(row: RefreshToken) -> Optional[List[UUID]]:
     raw_ids = row.authenticated_org_ids
     if not raw_ids:
         return None
@@ -64,6 +67,58 @@ def authenticated_org_ids_from_refresh_row(row: RefreshToken) -> Optional[List[U
         except (TypeError, ValueError):
             continue
     return org_ids or None
+
+
+def _epochs_from_refresh_row(row: RefreshToken) -> Optional[Dict[str, int]]:
+    raw_epochs = row.authenticated_org_epochs
+    if not isinstance(raw_epochs, dict):
+        return None
+    epochs: Dict[str, int] = {}
+    for key, value in raw_epochs.items():
+        try:
+            epochs[str(key)] = int(value)
+        except (TypeError, ValueError):
+            continue
+    return epochs or None
+
+
+def authenticated_org_ids_from_refresh_row(row: RefreshToken) -> Optional[List[UUID]]:
+    return _org_ids_from_refresh_row(row)
+
+
+def authenticated_org_auth_from_refresh_row(
+    row: RefreshToken,
+) -> Tuple[Optional[List[UUID]], Optional[Dict[str, int]]]:
+    return _org_ids_from_refresh_row(row), _epochs_from_refresh_row(row)
+
+
+def strip_org_from_user_refresh_auth(
+    db: Session,
+    *,
+    user_id: UUID,
+    organization_id: UUID,
+) -> None:
+    """Remove an org from password-auth lists on all active refresh tokens for a user."""
+    org_key = str(organization_id)
+    rows = (
+        db.query(RefreshToken)
+        .filter(
+            RefreshToken.user_id == user_id,
+            RefreshToken.revoked_at.is_(None),
+        )
+        .all()
+    )
+    for row in rows:
+        if row.authenticated_org_ids:
+            filtered_ids = [raw for raw in row.authenticated_org_ids if str(raw) != org_key]
+            row.authenticated_org_ids = filtered_ids or None
+        if isinstance(row.authenticated_org_epochs, dict):
+            epochs = {
+                str(key): value
+                for key, value in row.authenticated_org_epochs.items()
+                if str(key) != org_key
+            }
+            row.authenticated_org_epochs = epochs or None
 
 
 def validate_refresh_token(db: Session, raw: str) -> RefreshToken:

--- a/app/core/auth/refresh_tokens.py
+++ b/app/core/auth/refresh_tokens.py
@@ -77,3 +77,21 @@ def revoke_all_user_refresh_tokens(db: Session, user_id: UUID) -> None:
         )
         .update({RefreshToken.revoked_at: now}, synchronize_session=False)
     )
+
+
+def revoke_refresh_tokens_for_user_org(
+    db: Session,
+    *,
+    user_id: UUID,
+    organization_id: UUID,
+) -> None:
+    now = datetime.now(timezone.utc)
+    (
+        db.query(RefreshToken)
+        .filter(
+            RefreshToken.user_id == user_id,
+            RefreshToken.organization_id == organization_id,
+            RefreshToken.revoked_at.is_(None),
+        )
+        .update({RefreshToken.revoked_at: now}, synchronize_session=False)
+    )

--- a/app/core/auth/refresh_tokens.py
+++ b/app/core/auth/refresh_tokens.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import secrets
 from datetime import datetime, timedelta, timezone
+from typing import List, Optional, Sequence
 from uuid import UUID
 
 from sqlalchemy.orm import Session
@@ -28,20 +29,41 @@ def generate_refresh_token_value() -> str:
     return secrets.token_urlsafe(32)
 
 
-def issue_refresh_token(db: Session, *, user_id: UUID, organization_id: UUID) -> str:
+def issue_refresh_token(
+    db: Session,
+    *,
+    user_id: UUID,
+    organization_id: UUID,
+    authenticated_org_ids: Optional[Sequence[str]] = None,
+) -> str:
     """Create a new refresh token row and return the raw token value."""
     raw = generate_refresh_token_value()
     expires_at = datetime.now(timezone.utc) + timedelta(days=settings.AUTH_REFRESH_TOKEN_TTL_DAYS)
+    org_ids = list(authenticated_org_ids) if authenticated_org_ids else None
     db.add(
         RefreshToken(
             user_id=user_id,
             organization_id=organization_id,
             token_hash=_hash_token(raw),
             expires_at=expires_at,
+            authenticated_org_ids=org_ids,
         )
     )
     db.flush()
     return raw
+
+
+def authenticated_org_ids_from_refresh_row(row: RefreshToken) -> Optional[List[UUID]]:
+    raw_ids = row.authenticated_org_ids
+    if not raw_ids:
+        return None
+    org_ids: List[UUID] = []
+    for raw in raw_ids:
+        try:
+            org_ids.append(UUID(str(raw)))
+        except (TypeError, ValueError):
+            continue
+    return org_ids or None
 
 
 def validate_refresh_token(db: Session, raw: str) -> RefreshToken:

--- a/app/core/auth/session_epoch.py
+++ b/app/core/auth/session_epoch.py
@@ -1,0 +1,21 @@
+"""Session epoch helpers — invalidate all JWTs on password change."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from app.models.database import User
+
+
+def bump_user_session_epoch(user: User) -> int:
+    current = int(getattr(user, "session_epoch", 0) or 0)
+    user.session_epoch = current + 1
+    return user.session_epoch
+
+
+def bump_session_epoch_for_user_id(db: Session, user_id: UUID) -> None:
+    user = db.query(User).filter(User.id == user_id).first()
+    if user is not None:
+        bump_user_session_epoch(user)

--- a/app/core/auth/tokens.py
+++ b/app/core/auth/tokens.py
@@ -68,3 +68,14 @@ def decode_access_token(token: str) -> Dict[str, Any]:
     except JWTError:
         # Re-raise so caller can distinguish from other errors.
         raise
+
+
+def decode_access_token_allow_expired(token: str) -> Dict[str, Any]:
+    """Verify signature/issuer but allow expired tokens (e.g. refresh org list)."""
+    return jwt.decode(
+        token,
+        settings.SECRET_KEY,
+        algorithms=[ALGORITHM],
+        issuer=ISSUER,
+        options={"verify_exp": False, "verify_aud": False},
+    )

--- a/app/core/auth/tokens.py
+++ b/app/core/auth/tokens.py
@@ -29,6 +29,7 @@ def create_access_token(
     organization_id: UUID,
     email: str,
     session_epoch: int = 0,
+    authenticated_org_ids: Optional[list[str]] = None,
     expires_in_minutes: Optional[int] = None,
 ) -> Tuple[str, str, int]:
     """Issue a short-lived Bearer token for the given user/org.
@@ -46,6 +47,7 @@ def create_access_token(
         "org_id": str(organization_id),
         "email": email,
         "session_epoch": int(session_epoch or 0),
+        "authenticated_org_ids": authenticated_org_ids or [str(organization_id)],
         "jti": jti,
         "iat": int(now.timestamp()),
         "exp": int((now + timedelta(minutes=ttl_minutes)).timestamp()),

--- a/app/core/auth/tokens.py
+++ b/app/core/auth/tokens.py
@@ -28,6 +28,7 @@ def create_access_token(
     user_id: UUID,
     organization_id: UUID,
     email: str,
+    session_epoch: int = 0,
     expires_in_minutes: Optional[int] = None,
 ) -> Tuple[str, str, int]:
     """Issue a short-lived Bearer token for the given user/org.
@@ -44,6 +45,7 @@ def create_access_token(
         "sub": str(user_id),
         "org_id": str(organization_id),
         "email": email,
+        "session_epoch": int(session_epoch or 0),
         "jti": jti,
         "iat": int(now.timestamp()),
         "exp": int((now + timedelta(minutes=ttl_minutes)).timestamp()),

--- a/app/core/auth/tokens.py
+++ b/app/core/auth/tokens.py
@@ -30,6 +30,7 @@ def create_access_token(
     email: str,
     session_epoch: int = 0,
     authenticated_org_ids: Optional[list[str]] = None,
+    authenticated_org_epochs: Optional[dict[str, int]] = None,
     expires_in_minutes: Optional[int] = None,
 ) -> Tuple[str, str, int]:
     """Issue a short-lived Bearer token for the given user/org.
@@ -48,6 +49,8 @@ def create_access_token(
         "email": email,
         "session_epoch": int(session_epoch or 0),
         "authenticated_org_ids": authenticated_org_ids or [str(organization_id)],
+        "authenticated_org_epochs": authenticated_org_epochs
+        or {str(organization_id): int(session_epoch or 0)},
         "jti": jti,
         "iat": int(now.timestamp()),
         "exp": int((now + timedelta(minutes=ttl_minutes)).timestamp()),

--- a/app/core/csrf_middleware.py
+++ b/app/core/csrf_middleware.py
@@ -1,0 +1,94 @@
+"""CSRF protection for cookie-based browser sessions."""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import status
+from fastapi.responses import JSONResponse
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+
+from app.config import settings
+from app.core.auth.cookies import (
+    CSRF_HEADER,
+    cookie_session_enabled,
+    has_cookie_session,
+    read_csrf_cookie,
+)
+
+logger = logging.getLogger(__name__)
+
+_UNSAFE_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
+
+_CSRF_EXEMPT_SUFFIXES = (
+    "auth/login",
+    "auth/signup",
+    "auth/refresh",
+    "auth/config",
+    "auth/invitations/preview/",
+    "telephony/",
+    "public-blind-test/",
+)
+
+
+def _api_prefix() -> str:
+    prefix = settings.API_V1_PREFIX or "/api/v1"
+    return prefix.rstrip("/") + "/"
+
+
+def _path_after_prefix(path: str, prefix: str) -> str | None:
+    if not path.startswith(prefix):
+        return None
+    return path[len(prefix) :]
+
+
+def _is_csrf_exempt(remainder: str) -> bool:
+    for entry in _CSRF_EXEMPT_SUFFIXES:
+        if remainder == entry.rstrip("/") or remainder.startswith(entry):
+            return True
+    return False
+
+
+def _has_machine_api_key_header(request: Request) -> bool:
+    return bool(
+        request.headers.get("x-api-key")
+        or request.headers.get("x-efficientai-api-key")
+    )
+
+
+class CsrfMiddleware(BaseHTTPMiddleware):
+    """Require double-submit CSRF token for mutating cookie-authenticated requests."""
+
+    async def dispatch(self, request: Request, call_next):
+        if not cookie_session_enabled():
+            return await call_next(request)
+
+        if request.method.upper() not in _UNSAFE_METHODS:
+            return await call_next(request)
+
+        if not has_cookie_session(request):
+            return await call_next(request)
+
+        if _has_machine_api_key_header(request):
+            return await call_next(request)
+
+        prefix = _api_prefix()
+        remainder = _path_after_prefix(request.url.path, prefix)
+        if remainder is not None and _is_csrf_exempt(remainder):
+            return await call_next(request)
+
+        expected = read_csrf_cookie(request)
+        provided = request.headers.get(CSRF_HEADER) or request.headers.get("X-Csrf-Token")
+        if not expected or not provided or provided != expected:
+            logger.info(
+                "Blocked %s %s due to missing or invalid CSRF token",
+                request.method,
+                request.url.path,
+            )
+            return JSONResponse(
+                status_code=status.HTTP_403_FORBIDDEN,
+                content={"detail": "CSRF token missing or invalid"},
+            )
+
+        return await call_next(request)

--- a/app/core/csrf_middleware.py
+++ b/app/core/csrf_middleware.py
@@ -25,6 +25,7 @@ _CSRF_EXEMPT_SUFFIXES = (
     "auth/login",
     "auth/signup",
     "auth/refresh",
+    "auth/oidc/session",
     "auth/config",
     "auth/invitations/preview/",
     "telephony/",

--- a/app/core/csrf_middleware.py
+++ b/app/core/csrf_middleware.py
@@ -14,6 +14,7 @@ from app.core.auth.cookies import (
     CSRF_HEADER,
     cookie_session_enabled,
     has_cookie_session,
+    has_platform_cookie_session,
     read_csrf_cookie,
 )
 
@@ -28,6 +29,7 @@ _CSRF_EXEMPT_SUFFIXES = (
     "auth/oidc/session",
     "auth/config",
     "auth/invitations/preview/",
+    "platform/auth/login",
     "telephony/",
     "public-blind-test/",
 )
@@ -68,10 +70,11 @@ class CsrfMiddleware(BaseHTTPMiddleware):
         if request.method.upper() not in _UNSAFE_METHODS:
             return await call_next(request)
 
-        if not has_cookie_session(request):
+        has_browser_session = has_cookie_session(request) or has_platform_cookie_session(request)
+        if not has_browser_session:
             return await call_next(request)
 
-        if _has_machine_api_key_header(request):
+        if _has_machine_api_key_header(request) and not has_browser_session:
             return await call_next(request)
 
         prefix = _api_prefix()

--- a/app/core/health.py
+++ b/app/core/health.py
@@ -2,12 +2,37 @@
 
 from __future__ import annotations
 
+import time
+
+from app.config import settings
 from app.core.migrations import check_migrations_status
 
+_readiness_cached_at: float = 0.0
+_readiness_cached_status: tuple[bool, list[str]] = (True, [])
 
-def build_health_status(*, detailed: bool) -> tuple[dict, int]:
-    """Build health payload and HTTP status code."""
-    is_up_to_date, pending = check_migrations_status()
+
+def _migration_status_cached() -> tuple[bool, list[str]]:
+    global _readiness_cached_at, _readiness_cached_status
+
+    ttl = max(0, int(settings.HEALTH_READINESS_CACHE_SECONDS))
+    now = time.monotonic()
+    if ttl > 0 and (now - _readiness_cached_at) < ttl:
+        return _readiness_cached_status
+
+    status = check_migrations_status()
+    _readiness_cached_at = now
+    _readiness_cached_status = status
+    return status
+
+
+def build_liveness_status() -> tuple[dict, int]:
+    """Cheap liveness probe: no DB, no deployment state."""
+    return {"status": "ok"}, 200
+
+
+def build_readiness_status(*, detailed: bool) -> tuple[dict, int]:
+    """Readiness probe for load balancers: migrations must be current."""
+    is_up_to_date, pending = _migration_status_cached()
 
     if is_up_to_date:
         if detailed:
@@ -23,3 +48,8 @@ def build_health_status(*, detailed: bool) -> tuple[dict, int]:
         }, 503
 
     return {"status": "degraded"}, 503
+
+
+def build_health_status(*, detailed: bool) -> tuple[dict, int]:
+    """Backward-compatible alias for readiness checks."""
+    return build_readiness_status(detailed=detailed)

--- a/app/core/migration_middleware.py
+++ b/app/core/migration_middleware.py
@@ -19,7 +19,7 @@ _migrations_up_to_date = False
 
 
 def _migration_bypass_paths() -> list[str]:
-    paths = ["/health"]
+    paths = ["/health", "/health/ready"]
     if settings.DEBUG:
         paths.extend(["/docs", "/redoc", "/openapi.json"])
     return paths

--- a/app/core/migrations.py
+++ b/app/core/migrations.py
@@ -3,20 +3,26 @@ Database migration system that runs automatically on application startup.
 Migrations are tracked in a `schema_migrations` table to ensure they only run once.
 """
 
-import os
 import sys
 from pathlib import Path
-from typing import List, Optional, Tuple
-from sqlalchemy import text, inspect
+from typing import List, Set, Tuple
+from sqlalchemy import inspect, text
 from sqlalchemy.orm import Session, sessionmaker
-from sqlalchemy.exc import ProgrammingError
-from app.database import engine, SessionLocal, Base
 import logging
 
 logger = logging.getLogger(__name__)
 
-# Get migrations directory
 MIGRATIONS_DIR = Path(__file__).parent.parent / "migrations"
+
+
+def _sorted_migration_files() -> List[Path]:
+    if not MIGRATIONS_DIR.exists():
+        return []
+    return sorted(
+        path
+        for path in MIGRATIONS_DIR.glob("*.py")
+        if not path.stem.startswith("__")
+    )
 
 
 def _migration_scope_for_file(migration_file: Path) -> str:
@@ -31,20 +37,11 @@ def _migration_scope_for_file(migration_file: Path) -> str:
     return str(getattr(module, "MIGRATION_SCOPE", "all") or "all")
 
 
-def _migration_applies_to_engine(migration_file: Path, engine_role: str) -> bool:
-    if engine_role in ("all", "legacy"):
-        return True
-    scope = _migration_scope_for_file(migration_file)
-    if scope == "all":
-        return True
-    return scope == engine_role
-
-
-def _canonical_db_url_key(url: str) -> tuple:
+def _canonical_db_url_key(url) -> tuple:
     """Compare DB URLs ignoring driver suffix normalisation (postgresql vs postgresql+psycopg2)."""
-    from sqlalchemy.engine import make_url
+    from sqlalchemy.engine import URL, make_url
 
-    parsed = make_url(url)
+    parsed = url if isinstance(url, URL) else make_url(url)
     driver = (parsed.drivername or "").split("+", 1)[0]
     return (
         driver,
@@ -56,29 +53,78 @@ def _canonical_db_url_key(url: str) -> tuple:
     )
 
 
-def _engine_role_for_url(engine_url: str) -> str:
+def _is_catalog_engine_url(engine_url) -> bool:
     from app.config import settings
 
     if not getattr(settings, "DB_SHARDING_ENABLED", False):
-        return "legacy"
+        return True
     catalog_url = getattr(settings, "DB_CATALOG_URL", None) or settings.DATABASE_URL
     try:
-        if _canonical_db_url_key(engine_url) == _canonical_db_url_key(catalog_url):
-            return "catalog"
+        return _canonical_db_url_key(engine_url) == _canonical_db_url_key(catalog_url)
     except Exception:
-        if str(engine_url) == str(catalog_url):
-            return "catalog"
-    return "shard"
+        return str(engine_url) == str(catalog_url)
+
+
+def _migration_applies_to_engine(
+    migration_file: Path,
+    *,
+    is_catalog: bool,
+    sharding_enabled: bool,
+) -> bool:
+    if not sharding_enabled:
+        return True
+    scope = _migration_scope_for_file(migration_file)
+    if scope == "all":
+        return True
+    if scope == "catalog":
+        return is_catalog
+    if scope == "shard":
+        return not is_catalog
+    return True
+
+
+def _catalog_migration_gaps(applied: Set[str]) -> List[Path]:
+    """Catalog-scoped migrations missing while a later migration was already applied."""
+    gaps: List[Path] = []
+    all_files = _sorted_migration_files()
+    for migration_file in all_files:
+        version = migration_file.stem
+        if version in applied:
+            continue
+        if _migration_scope_for_file(migration_file) != "catalog":
+            continue
+        if any(other.stem in applied and other.stem > version for other in all_files):
+            gaps.append(migration_file)
+    return gaps
+
+
+def verify_catalog_schema(db: Session) -> List[str]:
+    """Return errors when required catalog auth schema is missing."""
+    errors: List[str] = []
+    inspector = inspect(db.get_bind())
+
+    if not inspector.has_table("users"):
+        return errors
+
+    user_columns = {column["name"] for column in inspector.get_columns("users")}
+    if "session_epoch" not in user_columns:
+        errors.append("users.session_epoch column missing")
+
+    if not inspector.has_table("organization_member_credentials"):
+        errors.append("organization_member_credentials table missing")
+
+    return errors
 
 
 class MigrationRunner:
     """Handles running database migrations in order."""
-    
-    def __init__(self, db: Session, *, engine_role: str = "legacy"):
+
+    def __init__(self, db: Session, *, is_catalog: bool, sharding_enabled: bool = False):
         self.db = db
-        self.engine_role = engine_role
+        self.is_catalog = is_catalog
+        self.sharding_enabled = sharding_enabled
         self.ensure_migrations_table()
-    
+
     def ensure_migrations_table(self):
         """Create the schema_migrations table if it doesn't exist."""
         try:
@@ -95,7 +141,7 @@ class MigrationRunner:
             logger.error(f"Error creating migrations table: {e}")
             self.db.rollback()
             raise
-    
+
     def get_applied_migrations(self) -> List[str]:
         """Get list of already applied migration versions."""
         try:
@@ -104,7 +150,7 @@ class MigrationRunner:
         except Exception as e:
             logger.error(f"Error fetching applied migrations: {e}")
             return []
-    
+
     def record_migration(self, version: str, description: str):
         """Record that a migration has been applied."""
         try:
@@ -118,60 +164,77 @@ class MigrationRunner:
             logger.error(f"Error recording migration: {e}")
             self.db.rollback()
             raise
-    
+
     def get_pending_migrations(self) -> List[Path]:
         """Get list of migration files that haven't been applied yet."""
         if not MIGRATIONS_DIR.exists():
             logger.warning(f"Migrations directory does not exist: {MIGRATIONS_DIR}")
             return []
-        
+
         applied = set(self.get_applied_migrations())
-        pending = []
-        
-        # Get all Python files in migrations directory, sorted by name
-        migration_files = sorted(MIGRATIONS_DIR.glob("*.py"))
-        
-        for migration_file in migration_files:
-            version = migration_file.stem  # filename without .py
-            if version not in applied and not version.startswith("__"):
-                if not _migration_applies_to_engine(migration_file, self.engine_role):
-                    continue
+        pending: List[Path] = []
+        skipped_catalog: List[str] = []
+
+        for migration_file in _sorted_migration_files():
+            version = migration_file.stem
+            if version in applied:
+                continue
+            if _migration_applies_to_engine(
+                migration_file,
+                is_catalog=self.is_catalog,
+                sharding_enabled=self.sharding_enabled,
+            ):
                 pending.append(migration_file)
-        
+            elif self.is_catalog and _migration_scope_for_file(migration_file) == "catalog":
+                skipped_catalog.append(version)
+
+        if self.is_catalog:
+            gap_versions = {path.stem for path in pending}
+            for migration_file in _catalog_migration_gaps(applied):
+                if migration_file.stem not in gap_versions:
+                    logger.warning(
+                        "Catalog migration gap detected: %s missing while later migrations are applied",
+                        migration_file.stem,
+                    )
+                    pending.append(migration_file)
+                    gap_versions.add(migration_file.stem)
+
+        if skipped_catalog:
+            logger.error(
+                "Catalog engine skipped required catalog migrations: %s",
+                ", ".join(skipped_catalog),
+            )
+
+        pending.sort(key=lambda path: path.stem)
         return pending
-    
+
     def run_migration(self, migration_file: Path) -> bool:
         """Run a single migration file."""
         version = migration_file.stem
         logger.info(f"Running migration: {version}")
-        
+
         try:
-            # Use importlib to handle module names starting with numbers
             import importlib.util
             spec = importlib.util.spec_from_file_location(f"migrations_{version}", migration_file)
             if spec is None or spec.loader is None:
                 logger.error(f"Could not load migration file: {migration_file}")
                 return False
-            
+
             migration_module = importlib.util.module_from_spec(spec)
             sys.modules[f"migrations_{version}"] = migration_module
             spec.loader.exec_module(migration_module)
-            
-            # Check if migration has upgrade function
+
             if not hasattr(migration_module, "upgrade"):
                 logger.error(f"Migration {version} does not have an 'upgrade' function")
                 return False
-            
-            # Run the migration
+
             migration_module.upgrade(self.db)
-            
-            # Record the migration
             description = getattr(migration_module, "description", "No description")
             self.record_migration(version, description)
-            
+
             logger.info(f"Successfully applied migration: {version}")
             return True
-            
+
         except Exception as e:
             import traceback
             logger.error(f"Error running migration {version}: {e}")
@@ -179,38 +242,36 @@ class MigrationRunner:
             self.db.rollback()
             return False
         finally:
-            # Clean up
             if f"migrations_{version}" in sys.modules:
                 del sys.modules[f"migrations_{version}"]
-    
+
     def run_all(self) -> bool:
         """Run all pending migrations."""
         pending = self.get_pending_migrations()
-        
+
         if not pending:
             logger.info("✅ No pending migrations - database is up to date")
             return True
-        
+
         logger.info(f"📋 Found {len(pending)} pending migration(s):")
         for migration_file in pending:
             logger.info(f"   - {migration_file.name}")
-        
+
         success = True
-        
+
         for migration_file in pending:
             logger.info("")
             logger.info(f"🔄 Applying migration: {migration_file.name}")
             if not self.run_migration(migration_file):
                 logger.error(f"❌ Failed to run migration: {migration_file.name}")
                 success = False
-                break  # Stop on first failure
-            else:
-                logger.info(f"✅ Successfully applied: {migration_file.name}")
-        
+                break
+            logger.info(f"✅ Successfully applied: {migration_file.name}")
+
         if success:
             logger.info("")
             logger.info("✅ All pending migrations completed successfully")
-        
+
         return success
 
 
@@ -219,15 +280,14 @@ def run_migrations():
     Run all pending database migrations.
     This should be called on application startup.
 
-    When sharding is enabled, applies the same migration set to each unique
-    engine URL (catalog + row shards) until catalog/shard split (Phase 8).
+    When sharding is enabled, catalog-scoped migrations run only on the catalog
+    engine URL; scope=all migrations run on catalog and every shard.
 
     Raises:
         RuntimeError: If migrations fail, preventing application startup
     """
     from app.db_sharding.pool_manager import db_pool_manager
 
-    # Ensure logging is configured at INFO level
     logging.basicConfig(
         level=logging.INFO,
         format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
@@ -238,15 +298,21 @@ def run_migrations():
     logger.info("🔄 Starting database migrations...")
     logger.info("=" * 60)
 
+    sharding_enabled = db_pool_manager.sharding_enabled
     engines = db_pool_manager.all_engines_for_migrations()
     for idx, eng in enumerate(engines):
         url_hint = str(eng.url).split("@")[-1] if eng.url else f"engine-{idx}"
-        logger.info("Migration target: %s", url_hint)
+        is_catalog = _is_catalog_engine_url(eng.url)
+        role_label = "catalog" if is_catalog else "shard"
+        logger.info("Migration target: %s (role=%s)", url_hint, role_label)
         factory = sessionmaker(autocommit=False, autoflush=False, bind=eng)
         db = factory()
         try:
-            engine_role = _engine_role_for_url(str(eng.url))
-            runner = MigrationRunner(db, engine_role=engine_role)
+            runner = MigrationRunner(
+                db,
+                is_catalog=is_catalog,
+                sharding_enabled=sharding_enabled,
+            )
 
             applied = runner.get_applied_migrations()
             pending = runner.get_pending_migrations()
@@ -259,6 +325,13 @@ def run_migrations():
                     logger.info(f"   ... and {len(applied) - 5} more")
 
             if not pending:
+                if is_catalog:
+                    schema_errors = verify_catalog_schema(db)
+                    if schema_errors:
+                        raise RuntimeError(
+                            "Catalog auth schema incomplete after migrations: "
+                            + "; ".join(schema_errors)
+                        )
                 logger.info("✅ Database is up to date - no migrations needed (%s)", url_hint)
                 continue
 
@@ -273,11 +346,20 @@ def run_migrations():
 
             final_pending = runner.get_pending_migrations()
             if final_pending:
-                logger.warning(
-                    f"⚠️  Warning: {len(final_pending)} migration(s) still pending after run on {url_hint}"
+                raise RuntimeError(
+                    f"{len(final_pending)} migration(s) still pending after run on {url_hint}: "
+                    + ", ".join(path.stem for path in final_pending)
                 )
-            else:
-                logger.info("✅ Verification complete - all migrations applied (%s)", url_hint)
+
+            if is_catalog:
+                schema_errors = verify_catalog_schema(db)
+                if schema_errors:
+                    raise RuntimeError(
+                        "Catalog auth schema incomplete after migrations: "
+                        + "; ".join(schema_errors)
+                    )
+
+            logger.info("✅ Verification complete - all migrations applied (%s)", url_hint)
         except RuntimeError:
             raise
         except Exception as e:
@@ -303,20 +385,29 @@ def check_migrations_status() -> Tuple[bool, List[str]]:
         Tuple of (is_up_to_date, pending_migration_names)
     """
     from app.db_sharding.pool_manager import db_pool_manager
-    from sqlalchemy.orm import sessionmaker
 
     pending_names: List[str] = []
     try:
+        sharding_enabled = db_pool_manager.sharding_enabled
         for eng in db_pool_manager.all_engines_for_migrations():
             factory = sessionmaker(autocommit=False, autoflush=False, bind=eng)
             db = factory()
             try:
-                engine_role = _engine_role_for_url(str(eng.url))
-                runner = MigrationRunner(db, engine_role=engine_role)
+                is_catalog = _is_catalog_engine_url(eng.url)
+                runner = MigrationRunner(
+                    db,
+                    is_catalog=is_catalog,
+                    sharding_enabled=sharding_enabled,
+                )
                 for migration_file in runner.get_pending_migrations():
                     name = migration_file.stem
                     if name not in pending_names:
                         pending_names.append(name)
+                if is_catalog:
+                    for error in verify_catalog_schema(db):
+                        marker = f"schema:{error}"
+                        if marker not in pending_names:
+                            pending_names.append(marker)
             finally:
                 db.close()
         return (len(pending_names) == 0, pending_names)
@@ -328,9 +419,7 @@ def check_migrations_status() -> Tuple[bool, List[str]]:
 def ensure_migrations_directory():
     """Ensure the migrations directory exists."""
     MIGRATIONS_DIR.mkdir(parents=True, exist_ok=True)
-    
-    # Create __init__.py if it doesn't exist
+
     init_file = MIGRATIONS_DIR / "__init__.py"
     if not init_file.exists():
         init_file.write_text("# Migrations package\n")
-

--- a/app/core/migrations.py
+++ b/app/core/migrations.py
@@ -294,24 +294,34 @@ def run_migrations():
 def check_migrations_status() -> Tuple[bool, List[str]]:
     """
     Check if there are any pending migrations.
-    
+
+    Uses the same engine list and per-engine ``MIGRATION_SCOPE`` rules as
+    ``run_migrations`` so readiness checks do not false-positive when sharding
+    is enabled.
+
     Returns:
         Tuple of (is_up_to_date, pending_migration_names)
-        - is_up_to_date: True if all migrations are applied
-        - pending_migration_names: List of pending migration file names
     """
+    from app.db_sharding.pool_manager import db_pool_manager
+    from sqlalchemy.orm import sessionmaker
+
+    pending_names: List[str] = []
     try:
-        db = SessionLocal()
-        try:
-            runner = MigrationRunner(db)
-            pending = runner.get_pending_migrations()
-            pending_names = [m.stem for m in pending]
-            return (len(pending) == 0, pending_names)
-        finally:
-            db.close()
+        for eng in db_pool_manager.all_engines_for_migrations():
+            factory = sessionmaker(autocommit=False, autoflush=False, bind=eng)
+            db = factory()
+            try:
+                engine_role = _engine_role_for_url(str(eng.url))
+                runner = MigrationRunner(db, engine_role=engine_role)
+                for migration_file in runner.get_pending_migrations():
+                    name = migration_file.stem
+                    if name not in pending_names:
+                        pending_names.append(name)
+            finally:
+                db.close()
+        return (len(pending_names) == 0, pending_names)
     except Exception as e:
         logger.error(f"Error checking migration status: {e}")
-        # If we can't check, assume migrations are needed (fail safe)
         return (False, ["unknown"])
 
 

--- a/app/core/observability_middleware.py
+++ b/app/core/observability_middleware.py
@@ -20,8 +20,9 @@ from fastapi import Request
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from app.config import settings
+from app.core.auth.dependency import resolve_request_credentials
+from app.core.auth.providers import get_provider_registry
 from app.database import get_db
-from app.core.security import get_api_key_organization_id
 
 logger = logging.getLogger(__name__)
 
@@ -36,14 +37,23 @@ def _get_client() -> httpx.AsyncClient:
 
 
 def _extract_org_id(request: Request) -> Optional[UUID]:
-    """Extract organization ID from the request's API key header."""
-    api_key = request.headers.get("X-API-Key") or request.headers.get("X-EFFICIENTAI-API-KEY")
-    if not api_key:
+    """Extract organization ID from API key, bearer token, or session cookie."""
+    cred = resolve_request_credentials(
+        authorization=request.headers.get("Authorization"),
+        x_api_key=request.headers.get("X-API-Key"),
+        x_eai_api_key=request.headers.get("X-EFFICIENTAI-API-KEY"),
+        request=request,
+    )
+    if not cred.bearer_token and not cred.api_key:
         return None
 
     db = next(get_db())
     try:
-        return get_api_key_organization_id(api_key, db)
+        provider = get_provider_registry().find(cred)
+        if provider is None:
+            return None
+        principal = provider.authenticate(cred, db)
+        return principal.organization_id
     except Exception:
         return None
     finally:

--- a/app/core/rbac_middleware.py
+++ b/app/core/rbac_middleware.py
@@ -3,27 +3,6 @@ ReaderReadOnlyMiddleware
 ========================
 
 Enforce a hard read-only boundary for callers whose org role is `reader`.
-
-Why a middleware: per-route role guards have to be added one-by-one and missed
-guards become silent privilege-escalation bugs. A middleware gives us a
-single, auditable choke point that turns *any* mutating request from a reader
-into a 403 - even on routes added later that forgot to wire up the dependency.
-
-Behavior
---------
-- Only inspects requests under the API prefix (`/api/v1/`).
-- Only inspects unsafe HTTP methods (`POST`, `PUT`, `PATCH`, `DELETE`).
-- Skips public/unauthenticated routes (login, signup, OIDC callback,
-  public blind-test form).
-- Skips a small allowlist of self-service routes that every member - including
-  readers - must be able to call (logout, accept/decline an invitation, change
-  their own password, update their own profile/preferences).
-- Resolves the caller's role using the same auth providers as `get_principal`
-  so this stays consistent with the rest of the app.
-
-If the caller is not authenticated at all, we let the request flow through so
-the existing per-route auth dependency can produce its standard 401 - we
-don't want this middleware to mask auth errors with 403s.
 """
 
 from __future__ import annotations
@@ -44,31 +23,23 @@ from app.models.database import RoleEnum
 
 logger = logging.getLogger(__name__)
 
-
-# Methods that mutate state. GET / HEAD / OPTIONS are always allowed.
 _UNSAFE_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
 
 
 def _api_prefix() -> str:
-    # `settings.API_V1_PREFIX` is e.g. `/api/v1`. Make sure it has a trailing
-    # slash for safe `startswith` matching so `/api/v1foo` doesn't match
-    # `/api/v1`.
     prefix = settings.API_V1_PREFIX or "/api/v1"
     return prefix.rstrip("/") + "/"
 
 
-# Paths under the API prefix that even a reader is allowed to POST/PUT/PATCH/DELETE
-# against. Match is "starts with" against the path *after* the API prefix.
-#
-# Keep this list tight: anything you put here is a write a reader can perform.
 _READER_WRITE_ALLOWLIST: tuple[str, ...] = (
-    # Auth: login, signup, logout, validate, switch own org, update own
-    # password. Access to these doesn't grant write access to org resources.
-    "auth/",
-    # Profile: own profile, own preferences, accept/decline invitations.
+    "auth/login",
+    "auth/signup",
+    "auth/logout",
+    "auth/refresh",
+    "auth/password",
+    "auth/switch-org",
+    "auth/invitations/",
     "profile",
-    # Public, unauthenticated blind-test submissions (rater UI). Auth is via
-    # an unguessable share_token in the body, not a Bearer token.
     "public-blind-test/",
 )
 
@@ -86,11 +57,29 @@ def _is_allowlisted(remainder: str, allowlist: Iterable[str]) -> bool:
     return False
 
 
+def _has_auth_credentials(request: Request) -> bool:
+    if (
+        request.headers.get("authorization")
+        or request.headers.get("x-api-key")
+        or request.headers.get("x-efficientai-api-key")
+    ):
+        return True
+    if (
+        request.query_params.get("token")
+        or request.query_params.get("access_token")
+        or request.query_params.get("api_key")
+        or request.query_params.get("X-API-Key")
+    ):
+        return True
+    if request.cookies.get("eai_access") or request.cookies.get("access_token") or request.cookies.get("api_key"):
+        return True
+    return False
+
+
 class ReaderReadOnlyMiddleware(BaseHTTPMiddleware):
     """Block mutating API calls coming from a `reader`-role member."""
 
     async def dispatch(self, request: Request, call_next):
-        # Fast path: only care about mutating methods on the API.
         if request.method.upper() not in _UNSAFE_METHODS:
             return await call_next(request)
 
@@ -99,33 +88,28 @@ class ReaderReadOnlyMiddleware(BaseHTTPMiddleware):
         if remainder is None:
             return await call_next(request)
 
-        # Self-service / public writes are always allowed.
         if _is_allowlisted(remainder, _READER_WRITE_ALLOWLIST):
             return await call_next(request)
 
-        # Pull credentials from the same headers the auth dependency reads.
+        if not _has_auth_credentials(request):
+            return await call_next(request)
+
         authorization = request.headers.get("authorization")
         x_api_key = request.headers.get("x-api-key")
         x_eai_api_key = request.headers.get("x-efficientai-api-key")
 
-        if not authorization and not x_api_key and not x_eai_api_key:
-            # Unauthenticated - let the route's own auth dep produce a 401.
-            return await call_next(request)
-
-        # Open a short-lived DB session just for the role lookup. The auth
-        # providers and the role query are read-only, so this doesn't fight
-        # the request's own session.
         db_gen = get_db()
         db = next(db_gen)
         try:
             try:
                 principal = _resolve_principal(
-                    authorization, x_api_key, x_eai_api_key, db
+                    authorization,
+                    x_api_key,
+                    x_eai_api_key,
+                    db,
+                    request=request,
                 )
             except Exception:
-                # If credential resolution itself raised (bad token, etc.),
-                # fall through and let the route's auth dep produce the
-                # standard error response.
                 return await call_next(request)
 
             if principal is None:

--- a/app/core/security_headers_middleware.py
+++ b/app/core/security_headers_middleware.py
@@ -52,4 +52,11 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
         _apply_cache_control(request, response)
         _apply_csp(response)
+        if settings.SECURITY_HSTS_ENABLED:
+            max_age = max(0, int(settings.SECURITY_HSTS_MAX_AGE))
+            if max_age > 0:
+                hsts = f"max-age={max_age}"
+                if settings.SECURITY_HSTS_INCLUDE_SUBDOMAINS:
+                    hsts += "; includeSubDomains"
+                response.headers["Strict-Transport-Security"] = hsts
         return response

--- a/app/core/trusted_host_middleware.py
+++ b/app/core/trusted_host_middleware.py
@@ -1,0 +1,69 @@
+"""Host header validation with load-balancer-friendly exemptions."""
+
+from __future__ import annotations
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import PlainTextResponse, Response
+
+from app.config import settings
+from app.core.operational_access_middleware import _ip_in_trusted
+
+_HEALTH_PATHS = {"/health"}
+
+
+def _normalize_path(path: str) -> str:
+    return path.rstrip("/") or "/"
+
+
+def _parse_host(request: Request) -> str | None:
+    raw = request.headers.get("host")
+    if not raw:
+        return None
+    raw = raw.strip()
+    if raw.startswith("["):
+        end = raw.find("]")
+        if end == -1:
+            return None
+        return raw[1:end]
+    if ":" in raw:
+        return raw.split(":", 1)[0]
+    return raw
+
+
+def _matches_trusted_host(host: str, allowed_hosts: list[str]) -> bool:
+    if "*" in allowed_hosts:
+        return True
+    for pattern in allowed_hosts:
+        if host == pattern:
+            return True
+        if pattern.startswith("*.") and host.endswith(pattern[1:]):
+            return True
+    return False
+
+
+def is_host_allowed(request: Request, allowed_hosts: list[str]) -> bool:
+    if _normalize_path(request.url.path) in _HEALTH_PATHS:
+        return True
+
+    host = _parse_host(request)
+    if host is None:
+        return False
+
+    if _matches_trusted_host(host, allowed_hosts):
+        return True
+
+    return _ip_in_trusted(host, settings.OPERATIONAL_TRUSTED_IPS)
+
+
+class SelectiveTrustedHostMiddleware(BaseHTTPMiddleware):
+    """Validate Host on API traffic; exempt /health and VPC IPs for LB probes."""
+
+    def __init__(self, app, allowed_hosts: list[str]) -> None:
+        super().__init__(app)
+        self.allowed_hosts = allowed_hosts
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        if not is_host_allowed(request, self.allowed_hosts):
+            return PlainTextResponse("Invalid host header", status_code=400)
+        return await call_next(request)

--- a/app/core/trusted_host_middleware.py
+++ b/app/core/trusted_host_middleware.py
@@ -9,7 +9,7 @@ from starlette.responses import PlainTextResponse, Response
 from app.config import settings
 from app.core.operational_access_middleware import _ip_in_trusted
 
-_HEALTH_PATHS = {"/health"}
+_HEALTH_PATHS = {"/health", "/health/ready"}
 
 
 def _normalize_path(path: str) -> str:

--- a/app/migrations/086_user_session_epoch.py
+++ b/app/migrations/086_user_session_epoch.py
@@ -1,0 +1,40 @@
+"""Add session_epoch to users for global session invalidation on password change."""
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+description = "Add users.session_epoch for password-change session invalidation"
+
+MIGRATION_SCOPE = "catalog"
+
+
+def _column_exists(db: Session, table_name: str, column_name: str) -> bool:
+    result = db.execute(
+        text(
+            """
+            SELECT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = :table_name AND column_name = :column_name
+            )
+            """
+        ),
+        {"table_name": table_name, "column_name": column_name},
+    )
+    return bool(result.scalar())
+
+
+def upgrade(db: Session) -> None:
+    if not _column_exists(db, "users", "session_epoch"):
+        db.execute(
+            text(
+                """
+                ALTER TABLE users
+                ADD COLUMN session_epoch INTEGER NOT NULL DEFAULT 0
+                """
+            )
+        )
+
+
+def downgrade(db: Session) -> None:
+    if _column_exists(db, "users", "session_epoch"):
+        db.execute(text("ALTER TABLE users DROP COLUMN session_epoch"))

--- a/app/migrations/086_user_session_epoch.py
+++ b/app/migrations/086_user_session_epoch.py
@@ -8,33 +8,23 @@ description = "Add users.session_epoch for password-change session invalidation"
 MIGRATION_SCOPE = "catalog"
 
 
-def _column_exists(db: Session, table_name: str, column_name: str) -> bool:
-    result = db.execute(
+def upgrade(db: Session) -> None:
+    db.execute(
         text(
             """
-            SELECT EXISTS (
-                SELECT 1 FROM information_schema.columns
-                WHERE table_name = :table_name AND column_name = :column_name
-            )
+            ALTER TABLE users
+            ADD COLUMN IF NOT EXISTS session_epoch INTEGER NOT NULL DEFAULT 0
             """
-        ),
-        {"table_name": table_name, "column_name": column_name},
-    )
-    return bool(result.scalar())
-
-
-def upgrade(db: Session) -> None:
-    if not _column_exists(db, "users", "session_epoch"):
-        db.execute(
-            text(
-                """
-                ALTER TABLE users
-                ADD COLUMN session_epoch INTEGER NOT NULL DEFAULT 0
-                """
-            )
         )
+    )
 
 
 def downgrade(db: Session) -> None:
-    if _column_exists(db, "users", "session_epoch"):
-        db.execute(text("ALTER TABLE users DROP COLUMN session_epoch"))
+    db.execute(
+        text(
+            """
+            ALTER TABLE users
+            DROP COLUMN IF EXISTS session_epoch
+            """
+        )
+    )

--- a/app/migrations/087_organization_member_credentials.py
+++ b/app/migrations/087_organization_member_credentials.py
@@ -1,0 +1,151 @@
+"""Add per-organization member credentials (password + session_epoch).
+
+Production-safe / idempotent:
+  - CREATE TABLE only when missing; indexes/constraints use IF NOT EXISTS.
+  - Backfill INSERTs missing rows only — never updates existing credentials.
+  - Explicit gen_random_uuid() in SELECT (works even if id has no DB default).
+  - Safe to re-run after a partial failure (empty table, failed insert, etc.).
+"""
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+description = "Add organization_member_credentials for org-scoped passwords and sessions"
+
+MIGRATION_SCOPE = "catalog"
+
+
+def _table_exists(db: Session, table_name: str) -> bool:
+    result = db.execute(
+        text(
+            """
+            SELECT EXISTS (
+                SELECT 1 FROM information_schema.tables
+                WHERE table_schema = 'public' AND table_name = :table_name
+            )
+            """
+        ),
+        {"table_name": table_name},
+    )
+    return bool(result.scalar())
+
+
+def _column_exists(db: Session, table_name: str, column_name: str) -> bool:
+    result = db.execute(
+        text(
+            """
+            SELECT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_schema = 'public'
+                  AND table_name = :table_name
+                  AND column_name = :column_name
+            )
+            """
+        ),
+        {"table_name": table_name, "column_name": column_name},
+    )
+    return bool(result.scalar())
+
+
+def upgrade(db: Session) -> None:
+    if not _table_exists(db, "organization_member_credentials"):
+        db.execute(
+            text(
+                """
+                CREATE TABLE organization_member_credentials (
+                    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                    organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+                    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                    password_hash VARCHAR(255),
+                    auth_provider VARCHAR(50),
+                    session_epoch INTEGER NOT NULL DEFAULT 0,
+                    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                    CONSTRAINT uq_org_member_credentials_org_user
+                        UNIQUE (organization_id, user_id)
+                )
+                """
+            )
+        )
+
+    # Belt-and-braces: create_all() may have created the table without a DB
+    # default on id; the backfill always supplies id explicitly, but set the
+    # default anyway for future app inserts.
+    db.execute(
+        text(
+            "ALTER TABLE organization_member_credentials "
+            "ALTER COLUMN id SET DEFAULT gen_random_uuid()"
+        )
+    )
+
+    db.execute(
+        text(
+            """
+            CREATE UNIQUE INDEX IF NOT EXISTS uq_org_member_credentials_org_user
+                ON organization_member_credentials (organization_id, user_id)
+            """
+        )
+    )
+    db.execute(
+        text(
+            """
+            CREATE INDEX IF NOT EXISTS ix_org_member_credentials_user_id
+                ON organization_member_credentials (user_id)
+            """
+        )
+    )
+    db.execute(
+        text(
+            """
+            CREATE INDEX IF NOT EXISTS ix_org_member_credentials_org_id
+                ON organization_member_credentials (organization_id)
+            """
+        )
+    )
+
+    # Backfill one credential row per membership from the legacy global user
+    # password/session. INSERT-only: existing rows (e.g. from a prior partial
+    # run or app writes) are left untouched.
+    session_epoch_expr = (
+        "COALESCE(u.session_epoch, 0)"
+        if _column_exists(db, "users", "session_epoch")
+        else "0"
+    )
+    db.execute(
+        text(
+            f"""
+            INSERT INTO organization_member_credentials (
+                id,
+                organization_id,
+                user_id,
+                password_hash,
+                auth_provider,
+                session_epoch,
+                created_at,
+                updated_at
+            )
+            SELECT
+                gen_random_uuid(),
+                om.organization_id,
+                om.user_id,
+                u.password_hash,
+                u.auth_provider,
+                {session_epoch_expr},
+                NOW(),
+                NOW()
+            FROM organization_members om
+            INNER JOIN users u ON u.id = om.user_id
+            WHERE NOT EXISTS (
+                SELECT 1
+                FROM organization_member_credentials c
+                WHERE c.organization_id = om.organization_id
+                  AND c.user_id = om.user_id
+            )
+            """
+        )
+    )
+
+
+def downgrade(db: Session) -> None:
+    if _table_exists(db, "organization_member_credentials"):
+        db.execute(text("DROP TABLE organization_member_credentials"))

--- a/app/migrations/088_refresh_token_authenticated_org_ids.py
+++ b/app/migrations/088_refresh_token_authenticated_org_ids.py
@@ -1,0 +1,28 @@
+"""Persist authenticated_org_ids on refresh tokens for silent refresh."""
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+description = "Add authenticated_org_ids to refresh_tokens"
+
+
+def upgrade(db: Session) -> None:
+    db.execute(
+        text(
+            """
+            ALTER TABLE refresh_tokens
+            ADD COLUMN IF NOT EXISTS authenticated_org_ids JSONB
+            """
+        )
+    )
+
+
+def downgrade(db: Session) -> None:
+    db.execute(
+        text(
+            """
+            ALTER TABLE refresh_tokens
+            DROP COLUMN IF EXISTS authenticated_org_ids
+            """
+        )
+    )

--- a/app/migrations/089_refresh_token_authenticated_org_epochs.py
+++ b/app/migrations/089_refresh_token_authenticated_org_epochs.py
@@ -1,0 +1,28 @@
+"""Persist authenticated_org_epochs on refresh tokens for cross-org auth validation."""
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+description = "Add authenticated_org_epochs to refresh_tokens"
+
+
+def upgrade(db: Session) -> None:
+    db.execute(
+        text(
+            """
+            ALTER TABLE refresh_tokens
+            ADD COLUMN IF NOT EXISTS authenticated_org_epochs JSONB
+            """
+        )
+    )
+
+
+def downgrade(db: Session) -> None:
+    db.execute(
+        text(
+            """
+            ALTER TABLE refresh_tokens
+            DROP COLUMN IF EXISTS authenticated_org_epochs
+            """
+        )
+    )

--- a/app/migrations/090_organization_member_session_revocations.py
+++ b/app/migrations/090_organization_member_session_revocations.py
@@ -1,0 +1,34 @@
+"""Track minimum session epoch after org membership removal."""
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+description = "Add organization_member_session_revocations"
+
+
+def upgrade(db: Session) -> None:
+    db.execute(
+        text(
+            """
+            CREATE TABLE IF NOT EXISTS organization_member_session_revocations (
+                organization_id UUID NOT NULL
+                    REFERENCES organizations(id) ON DELETE CASCADE,
+                user_id UUID NOT NULL
+                    REFERENCES users(id) ON DELETE CASCADE,
+                min_session_epoch INTEGER NOT NULL DEFAULT 1,
+                revoked_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                PRIMARY KEY (organization_id, user_id)
+            )
+            """
+        )
+    )
+
+
+def downgrade(db: Session) -> None:
+    db.execute(
+        text(
+            """
+            DROP TABLE IF EXISTS organization_member_session_revocations
+            """
+        )
+    )

--- a/app/migrations/091_catalog_security_schema_repair.py
+++ b/app/migrations/091_catalog_security_schema_repair.py
@@ -1,0 +1,148 @@
+"""Repair catalog auth schema when 086/087 were skipped (out-of-order deploy).
+
+Idempotent: safe when 086/087 already applied normally.
+"""
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+description = "Repair catalog auth schema (session_epoch + organization_member_credentials)"
+
+MIGRATION_SCOPE = "catalog"
+
+
+def _table_exists(db: Session, table_name: str) -> bool:
+    result = db.execute(
+        text(
+            """
+            SELECT EXISTS (
+                SELECT 1 FROM information_schema.tables
+                WHERE table_schema = 'public' AND table_name = :table_name
+            )
+            """
+        ),
+        {"table_name": table_name},
+    )
+    return bool(result.scalar())
+
+
+def _column_exists(db: Session, table_name: str, column_name: str) -> bool:
+    result = db.execute(
+        text(
+            """
+            SELECT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_schema = 'public'
+                  AND table_name = :table_name
+                  AND column_name = :column_name
+            )
+            """
+        ),
+        {"table_name": table_name, "column_name": column_name},
+    )
+    return bool(result.scalar())
+
+
+def upgrade(db: Session) -> None:
+    db.execute(
+        text(
+            """
+            ALTER TABLE users
+            ADD COLUMN IF NOT EXISTS session_epoch INTEGER NOT NULL DEFAULT 0
+            """
+        )
+    )
+
+    if not _table_exists(db, "organization_member_credentials"):
+        db.execute(
+            text(
+                """
+                CREATE TABLE organization_member_credentials (
+                    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                    organization_id UUID NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+                    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                    password_hash VARCHAR(255),
+                    auth_provider VARCHAR(50),
+                    session_epoch INTEGER NOT NULL DEFAULT 0,
+                    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                    CONSTRAINT uq_org_member_credentials_org_user
+                        UNIQUE (organization_id, user_id)
+                )
+                """
+            )
+        )
+
+    db.execute(
+        text(
+            "ALTER TABLE organization_member_credentials "
+            "ALTER COLUMN id SET DEFAULT gen_random_uuid()"
+        )
+    )
+    db.execute(
+        text(
+            """
+            CREATE UNIQUE INDEX IF NOT EXISTS uq_org_member_credentials_org_user
+                ON organization_member_credentials (organization_id, user_id)
+            """
+        )
+    )
+    db.execute(
+        text(
+            """
+            CREATE INDEX IF NOT EXISTS ix_org_member_credentials_user_id
+                ON organization_member_credentials (user_id)
+            """
+        )
+    )
+    db.execute(
+        text(
+            """
+            CREATE INDEX IF NOT EXISTS ix_org_member_credentials_org_id
+                ON organization_member_credentials (organization_id)
+            """
+        )
+    )
+
+    session_epoch_expr = (
+        "COALESCE(u.session_epoch, 0)"
+        if _column_exists(db, "users", "session_epoch")
+        else "0"
+    )
+    db.execute(
+        text(
+            f"""
+            INSERT INTO organization_member_credentials (
+                id,
+                organization_id,
+                user_id,
+                password_hash,
+                auth_provider,
+                session_epoch,
+                created_at,
+                updated_at
+            )
+            SELECT
+                gen_random_uuid(),
+                om.organization_id,
+                om.user_id,
+                u.password_hash,
+                u.auth_provider,
+                {session_epoch_expr},
+                NOW(),
+                NOW()
+            FROM organization_members om
+            INNER JOIN users u ON u.id = om.user_id
+            WHERE NOT EXISTS (
+                SELECT 1
+                FROM organization_member_credentials c
+                WHERE c.organization_id = om.organization_id
+                  AND c.user_id = om.user_id
+            )
+            """
+        )
+    )
+
+
+def downgrade(db: Session) -> None:
+    pass

--- a/app/models/database.py
+++ b/app/models/database.py
@@ -252,6 +252,7 @@ class User(Base):
     external_id = Column(String(255), unique=True, nullable=True, index=True)
     auth_provider = Column(String(50), nullable=True)
     mfa_enabled = Column(Boolean, default=False, nullable=False)
+    session_epoch = Column(Integer, default=0, nullable=False, server_default="0")
     last_login_at = Column(DateTime(timezone=True), nullable=True)
     is_active = Column(Boolean, default=True, nullable=False)
     created_at = Column(DateTime(timezone=True), server_default=func.now())

--- a/app/models/database.py
+++ b/app/models/database.py
@@ -373,6 +373,21 @@ class OrganizationMemberCredential(Base):
     )
 
 
+class OrganizationMemberSessionRevocation(Base):
+    """Minimum valid session epoch after membership removal for a user/org pair."""
+
+    __tablename__ = "organization_member_session_revocations"
+
+    organization_id = Column(
+        UUID(as_uuid=True), ForeignKey("organizations.id", ondelete="CASCADE"), primary_key=True
+    )
+    user_id = Column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), primary_key=True
+    )
+    min_session_epoch = Column(Integer, nullable=False, server_default="1")
+    revoked_at = Column(DateTime(timezone=True), server_default=func.now())
+
+
 class Invitation(Base):
     """Invitation model for inviting users to organizations."""
 

--- a/app/models/database.py
+++ b/app/models/database.py
@@ -317,6 +317,7 @@ class RefreshToken(Base):
     token_hash = Column(String(64), unique=True, nullable=False, index=True)
     expires_at = Column(DateTime(timezone=True), nullable=False)
     revoked_at = Column(DateTime(timezone=True), nullable=True)
+    authenticated_org_ids = Column(JSON, nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
 
     user = relationship("User", back_populates="refresh_tokens")

--- a/app/models/database.py
+++ b/app/models/database.py
@@ -348,6 +348,29 @@ class OrganizationMember(Base):
     default_agent = relationship("Agent", foreign_keys=[default_agent_id])
 
 
+class OrganizationMemberCredential(Base):
+    """Per-organization password and session state for a membership."""
+
+    __tablename__ = "organization_member_credentials"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    organization_id = Column(
+        UUID(as_uuid=True), ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    user_id = Column(
+        UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    password_hash = Column(String(255), nullable=True)
+    auth_provider = Column(String(50), nullable=True)
+    session_epoch = Column(Integer, default=0, nullable=False, server_default="0")
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now())
+
+    __table_args__ = (
+        UniqueConstraint("organization_id", "user_id", name="uq_org_member_credentials_org_user"),
+    )
+
+
 class Invitation(Base):
     """Invitation model for inviting users to organizations."""
 

--- a/app/models/database.py
+++ b/app/models/database.py
@@ -318,6 +318,7 @@ class RefreshToken(Base):
     expires_at = Column(DateTime(timezone=True), nullable=False)
     revoked_at = Column(DateTime(timezone=True), nullable=True)
     authenticated_org_ids = Column(JSON, nullable=True)
+    authenticated_org_epochs = Column(JSON, nullable=True)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
 
     user = relationship("User", back_populates="refresh_tokens")

--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -727,10 +727,11 @@ class UserCreate(BaseModel):
 
 class UserUpdate(BaseModel):
     """Schema for updating user profile."""
+    model_config = ConfigDict(extra="forbid")
+
     name: Optional[str] = None
     first_name: Optional[str] = None
     last_name: Optional[str] = None
-    email: Optional[str] = None
 
 
 class UserResponse(BaseModel):

--- a/app/services/ai/llm_config_safety.py
+++ b/app/services/ai/llm_config_safety.py
@@ -1,0 +1,56 @@
+"""Strip dangerous LiteLLM overrides from client-supplied config."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, Set
+
+_BLOCKED_LLM_CONFIG_KEYS: Set[str] = {
+    "api_base",
+    "api_key",
+    "api_version",
+    "base_url",
+    "azure_endpoint",
+    "azure_ad_token",
+    "aws_access_key_id",
+    "aws_secret_access_key",
+    "aws_region_name",
+    "extra_headers",
+    "headers",
+    "authorization",
+    "litellm_proxy_api_key",
+    "proxy",
+    "custom_llm_provider",
+    "model",
+    "model_id",
+}
+
+_ALLOWED_LLM_CONFIG_KEYS: Set[str] = {
+    "temperature",
+    "max_tokens",
+    "top_p",
+    "top_k",
+    "frequency_penalty",
+    "presence_penalty",
+    "seed",
+    "stop",
+    "n",
+    "response_format",
+    "timeout",
+}
+
+
+def sanitize_client_llm_config(
+    config: Optional[Dict[str, Any]],
+) -> Optional[Dict[str, Any]]:
+    if not config:
+        return None
+    sanitized: Dict[str, Any] = {}
+    for key, value in config.items():
+        normalized = str(key).strip().lower()
+        if normalized in _BLOCKED_LLM_CONFIG_KEYS:
+            continue
+        if normalized not in _ALLOWED_LLM_CONFIG_KEYS:
+            continue
+        if value is not None:
+            sanitized[key] = value
+    return sanitized or None

--- a/app/services/ai/llm_gateway_settings.py
+++ b/app/services/ai/llm_gateway_settings.py
@@ -13,7 +13,10 @@ from uuid import UUID
 from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
+from app.config import settings
 from app.models.database import Organization
+from app.services.telephony.exotel_client import ExotelInvalidContentError
+from app.services.telephony.recording_download import assert_outbound_http_url_safe
 from app.services.ai.llm_gateway import (
     EffectiveRouting,
     GatewayInterface,
@@ -195,7 +198,13 @@ def set_org_settings(
                     effective_type_for_validation,
                     effective_interface_for_validation,
                 )
+                assert_outbound_http_url_safe(
+                    trimmed,
+                    allow_loopback=bool(settings.DEBUG),
+                )
             except ValueError as exc:
+                raise HTTPException(status_code=400, detail=str(exc)) from exc
+            except ExotelInvalidContentError as exc:
                 raise HTTPException(status_code=400, detail=str(exc)) from exc
             payload["base_url"] = trimmed
         else:

--- a/app/services/invitation_service.py
+++ b/app/services/invitation_service.py
@@ -214,21 +214,30 @@ def build_invite_join_notice(
         source_organization_id is not None
         and source_organization_id != organization_id
     ):
-        source_org = (
-            db.query(Organization)
-            .filter(Organization.id == source_organization_id)
-            .first()
+        source_cred = get_credential(
+            db, user_id=user.id, organization_id=source_organization_id
         )
-        if source_org is not None:
-            return (
-                f"You've joined {organization_name}. "
-                f"You can sign in with the same password you use for {source_org.name}. "
-                "Each organization has its own password."
+        if (
+            source_cred is not None
+            and source_cred.password_hash
+            and credential.password_hash == source_cred.password_hash
+        ):
+            source_org = (
+                db.query(Organization)
+                .filter(Organization.id == source_organization_id)
+                .first()
             )
+            if source_org is not None:
+                return (
+                    f"You've joined {organization_name}. "
+                    f"You can sign in with the same password you use for {source_org.name}. "
+                    "Each organization has its own password."
+                )
 
     return (
         f"You've joined {organization_name}. "
-        "You can sign in with your existing password. Each organization has its own password."
+        "Sign in with the password for this organization. "
+        "Each organization has its own password."
     )
 
 

--- a/app/services/invitation_service.py
+++ b/app/services/invitation_service.py
@@ -132,6 +132,15 @@ def accept_invitation(
         role=invitation.role,
     )
     db.add(member)
+    db.flush()
+
+    from app.core.auth.org_credentials import provision_membership_credential
+
+    provision_membership_credential(
+        db,
+        user_id=user.id,
+        organization_id=invitation.organization_id,
+    )
 
     invitation.status = InvitationStatus.ACCEPTED
     invitation.accepted_at = datetime.now(timezone.utc)

--- a/app/services/invitation_service.py
+++ b/app/services/invitation_service.py
@@ -174,13 +174,9 @@ def get_invitation_preview(db: Session, token: str) -> dict:
     user_exists = existing_user is not None
     has_password = False
     if existing_user is not None:
-        from app.core.auth.org_credentials import org_has_password
+        from app.core.auth.org_credentials import user_has_any_local_password
 
-        has_password = org_has_password(
-            db,
-            user=existing_user,
-            organization_id=invitation.organization_id,
-        )
+        has_password = user_has_any_local_password(db, existing_user)
 
     status_value = getattr(invitation.status, "value", invitation.status)
     return {
@@ -192,6 +188,48 @@ def get_invitation_preview(db: Session, token: str) -> dict:
         "user_exists": user_exists,
         "has_password": has_password,
     }
+
+
+def build_invite_join_notice(
+    db: Session,
+    *,
+    user: User,
+    organization_id: UUID,
+    organization_name: str,
+    source_organization_id: Optional[UUID] = None,
+) -> Optional[str]:
+    """Short UX hint after joining via invite (existing users only)."""
+    from app.core.auth.org_credentials import get_credential
+
+    credential = get_credential(
+        db, user_id=user.id, organization_id=organization_id
+    )
+    if credential is None or not credential.password_hash:
+        return (
+            f"You've joined {organization_name}. "
+            "Set a password for this organization in Profile so you can sign in again later."
+        )
+
+    if (
+        source_organization_id is not None
+        and source_organization_id != organization_id
+    ):
+        source_org = (
+            db.query(Organization)
+            .filter(Organization.id == source_organization_id)
+            .first()
+        )
+        if source_org is not None:
+            return (
+                f"You've joined {organization_name}. "
+                f"You can sign in with the same password you use for {source_org.name}. "
+                "Each organization has its own password."
+            )
+
+    return (
+        f"You've joined {organization_name}. "
+        "You can sign in with your existing password. Each organization has its own password."
+    )
 
 
 def invitation_to_response_dict(

--- a/app/services/invitation_service.py
+++ b/app/services/invitation_service.py
@@ -159,7 +159,15 @@ def get_invitation_preview(db: Session, token: str) -> dict:
     )
     existing_user = db.query(User).filter(User.email == invitation.email).first()
     user_exists = existing_user is not None
-    has_password = bool(existing_user and existing_user.password_hash)
+    has_password = False
+    if existing_user is not None:
+        from app.core.auth.org_credentials import org_has_password
+
+        has_password = org_has_password(
+            db,
+            user=existing_user,
+            organization_id=invitation.organization_id,
+        )
 
     status_value = getattr(invitation.status, "value", invitation.status)
     return {

--- a/app/services/invitation_service.py
+++ b/app/services/invitation_service.py
@@ -140,6 +140,7 @@ def accept_invitation(
         db,
         user_id=user.id,
         organization_id=invitation.organization_id,
+        user=user,
     )
 
     invitation.status = InvitationStatus.ACCEPTED

--- a/app/services/invitation_service.py
+++ b/app/services/invitation_service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from typing import Optional
+from uuid import UUID
 
 from sqlalchemy.orm import Session
 
@@ -88,6 +89,7 @@ def accept_invitation(
     user: User,
     *,
     require_email_match: bool = True,
+    source_organization_id: Optional[UUID] = None,
 ) -> OrganizationMember:
     """
     Accept an invitation and add the user to the organization.
@@ -141,6 +143,7 @@ def accept_invitation(
         user_id=user.id,
         organization_id=invitation.organization_id,
         user=user,
+        source_organization_id=source_organization_id,
     )
 
     invitation.status = InvitationStatus.ACCEPTED

--- a/app/services/media_urls.py
+++ b/app/services/media_urls.py
@@ -63,7 +63,7 @@ def ws_base_from_http_host(host: str, *, scheme: str = "http") -> str:
 
 def build_voice_agent_ws_url(
     *,
-    auth_query: str,
+    auth_query: Optional[str] = None,
     agent_id: Optional[str] = None,
     persona_id: Optional[str] = None,
     scenario_id: Optional[str] = None,
@@ -91,16 +91,21 @@ def build_voice_agent_ws_url(
     else:
         base = f"ws://localhost:{settings.PORT}"
 
-    query = auth_query
+    query_parts: list[str] = []
+    if auth_query:
+        query_parts.append(auth_query)
     if agent_id:
-        query += f"&agent_id={quote(agent_id)}"
+        query_parts.append(f"agent_id={quote(agent_id)}")
     if persona_id:
-        query += f"&persona_id={quote(persona_id)}"
+        query_parts.append(f"persona_id={quote(persona_id)}")
     if scenario_id:
-        query += f"&scenario_id={quote(scenario_id)}"
+        query_parts.append(f"scenario_id={quote(scenario_id)}")
     if run_evaluation:
-        query += "&run_evaluation=true"
+        query_parts.append("run_evaluation=true")
     if ui_surface:
-        query += f"&ui_surface={quote(ui_surface, safe='')}"
+        query_parts.append(f"ui_surface={quote(ui_surface, safe='')}")
 
-    return f"{base}{settings.API_V1_PREFIX}/voice-agent/ws?{query}"
+    path = f"{base}{settings.API_V1_PREFIX}/voice-agent/ws"
+    if not query_parts:
+        return path
+    return f"{path}?{'&'.join(query_parts)}"

--- a/app/services/media_urls.py
+++ b/app/services/media_urls.py
@@ -76,6 +76,16 @@ def build_voice_agent_ws_url(
     ws_base = media_ws_base_url()
     if ws_base:
         base = ws_base
+    elif (settings.PUBLIC_BASE_URL or "").strip():
+        public = settings.PUBLIC_BASE_URL.strip().rstrip("/")
+        if public.startswith("https://"):
+            base = "wss://" + public[len("https://") :]
+        elif public.startswith("http://"):
+            base = "ws://" + public[len("http://") :]
+        elif public.startswith("wss://") or public.startswith("ws://"):
+            base = public
+        else:
+            base = f"wss://{public}"
     elif fallback_host:
         base = ws_base_from_http_host(fallback_host, scheme=fallback_scheme)
     else:

--- a/app/services/media_urls.py
+++ b/app/services/media_urls.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 from typing import Optional
-from urllib.parse import quote
+from urllib.parse import quote, urlparse
+
+from starlette.requests import Request
 
 from app.config import settings
 
@@ -61,6 +63,38 @@ def ws_base_from_http_host(host: str, *, scheme: str = "http") -> str:
     return f"{ws_scheme}://{host.rstrip('/')}"
 
 
+def resolve_voice_agent_ws_base(
+    *,
+    fallback_host: Optional[str] = None,
+    fallback_scheme: str = "http",
+) -> str:
+    """Resolve the WebSocket origin used for browser voice-agent connections."""
+    ws_base = media_ws_base_url()
+    if ws_base:
+        return ws_base
+    if (settings.PUBLIC_BASE_URL or "").strip():
+        public = settings.PUBLIC_BASE_URL.strip().rstrip("/")
+        if public.startswith("https://"):
+            return "wss://" + public[len("https://") :]
+        if public.startswith("http://"):
+            return "ws://" + public[len("http://") :]
+        if public.startswith("wss://") or public.startswith("ws://"):
+            return public
+        return f"wss://{public}"
+    if fallback_host:
+        return ws_base_from_http_host(fallback_host, scheme=fallback_scheme)
+    return f"ws://localhost:{settings.PORT}"
+
+
+def cross_host_voice_ws(ws_base: str, request: Request) -> bool:
+    """True when the WS host cannot receive the API's host-scoped session cookies."""
+    ws_hostname = (urlparse(ws_base).hostname or "").lower()
+    req_hostname = (request.url.hostname or "").lower()
+    if not ws_hostname or not req_hostname:
+        return False
+    return ws_hostname != req_hostname
+
+
 def build_voice_agent_ws_url(
     *,
     auth_query: Optional[str] = None,
@@ -73,23 +107,10 @@ def build_voice_agent_ws_url(
     fallback_scheme: str = "http",
 ) -> str:
     """Build the browser voice-agent WebSocket URL."""
-    ws_base = media_ws_base_url()
-    if ws_base:
-        base = ws_base
-    elif (settings.PUBLIC_BASE_URL or "").strip():
-        public = settings.PUBLIC_BASE_URL.strip().rstrip("/")
-        if public.startswith("https://"):
-            base = "wss://" + public[len("https://") :]
-        elif public.startswith("http://"):
-            base = "ws://" + public[len("http://") :]
-        elif public.startswith("wss://") or public.startswith("ws://"):
-            base = public
-        else:
-            base = f"wss://{public}"
-    elif fallback_host:
-        base = ws_base_from_http_host(fallback_host, scheme=fallback_scheme)
-    else:
-        base = f"ws://localhost:{settings.PORT}"
+    base = resolve_voice_agent_ws_base(
+        fallback_host=fallback_host,
+        fallback_scheme=fallback_scheme,
+    )
 
     query_parts: list[str] = []
     if auth_query:

--- a/app/services/telephony/recording_download.py
+++ b/app/services/telephony/recording_download.py
@@ -23,16 +23,25 @@ from app.services.telephony.exotel_client import (
 )
 
 _DEFAULT_ALLOWED_HOST_SUFFIXES = (
+    # Telephony carriers
     "exotel.com",
     "plivo.com",
+    "vobiz.ai",
+    # Object storage / CDN (provider recording artifacts)
     "amazonaws.com",
     "cloudfront.net",
     "googleapis.com",
+    "blob.core.windows.net",
+    "digitaloceanspaces.com",
+    "backblazeb2.com",
+    "r2.cloudflarestorage.com",
+    # Voice AI platforms
     "vapi.ai",
     "retell.ai",
     "elevenlabs.io",
     "daily.co",
     "livekit.cloud",
+    "smallest.ai",
 )
 
 # Credentialed telephony fetches must not send Basic auth to shared storage hosts.
@@ -57,10 +66,16 @@ _BLOCKED_NETWORKS = (
 
 
 def _allowed_host_suffixes() -> List[str]:
-    configured = getattr(settings, "RECORDING_URL_ALLOWED_HOST_SUFFIXES", None)
-    if configured:
-        return list(configured)
-    return list(_DEFAULT_ALLOWED_HOST_SUFFIXES)
+    """Built-in provider suffixes plus any extra entries from config/env."""
+    merged = list(_DEFAULT_ALLOWED_HOST_SUFFIXES)
+    configured = getattr(settings, "RECORDING_URL_ALLOWED_HOST_SUFFIXES", None) or []
+    seen = {suffix.lower() for suffix in merged}
+    for suffix in configured:
+        normalized = str(suffix).strip().lstrip(".").lower()
+        if normalized and normalized not in seen:
+            merged.append(normalized)
+            seen.add(normalized)
+    return merged
 
 
 def _hostname_allowed(hostname: str, allowed_suffixes: List[str]) -> bool:

--- a/app/services/telephony/recording_download.py
+++ b/app/services/telephony/recording_download.py
@@ -27,6 +27,12 @@ _DEFAULT_ALLOWED_HOST_SUFFIXES = (
     "plivo.com",
     "amazonaws.com",
     "cloudfront.net",
+    "googleapis.com",
+    "vapi.ai",
+    "retell.ai",
+    "elevenlabs.io",
+    "daily.co",
+    "livekit.cloud",
 )
 
 # Credentialed telephony fetches must not send Basic auth to shared storage hosts.
@@ -158,6 +164,35 @@ def assert_recording_url_safe(
             raise ExotelInvalidContentError(
                 "Recording URL resolves to a blocked network address"
             )
+
+
+def assert_safe_provider_recording_url(recording_url: str) -> None:
+    """Validate provider-stored recording URLs before server-side HTTP fetch."""
+    assert_recording_url_safe(recording_url, user_supplied=False)
+
+
+def assert_outbound_http_url_safe(url: str, *, allow_loopback: bool = False) -> None:
+    """Block SSRF to private/metadata networks for operator-configured URLs."""
+    parsed = urlparse(url.strip())
+    if parsed.scheme not in {"http", "https"}:
+        raise ExotelInvalidContentError(
+            f"URL must use http or https, got {parsed.scheme or 'none'}"
+        )
+    if not parsed.hostname:
+        raise ExotelInvalidContentError("URL is missing a hostname")
+
+    hostname = parsed.hostname
+    try:
+        literal_ip = ipaddress.ip_address(hostname)
+        if _ip_is_blocked(literal_ip) and not (allow_loopback and literal_ip.is_loopback):
+            raise ExotelInvalidContentError("URL targets a blocked network address")
+        return
+    except ValueError:
+        pass
+
+    for resolved_ip in _resolve_host_ips(hostname):
+        if _ip_is_blocked(resolved_ip) and not (allow_loopback and resolved_ip.is_loopback):
+            raise ExotelInvalidContentError("URL resolves to a blocked network address")
 
 
 def download_recording_url(

--- a/app/services/workspace_rbac.py
+++ b/app/services/workspace_rbac.py
@@ -205,6 +205,31 @@ def count_workspace_admins(db: Session, *, workspace_id: UUID) -> int:
     return count
 
 
+def remove_user_org_workspace_memberships(
+    db: Session,
+    *,
+    organization_id: UUID,
+    user_id: UUID,
+) -> int:
+    """Drop workspace memberships for a user across all workspaces in an org."""
+    workspace_ids = [
+        row[0]
+        for row in db.query(Workspace.id)
+        .filter(Workspace.organization_id == organization_id)
+        .all()
+    ]
+    if not workspace_ids:
+        return 0
+    return (
+        db.query(WorkspaceMember)
+        .filter(
+            WorkspaceMember.user_id == user_id,
+            WorkspaceMember.workspace_id.in_(workspace_ids),
+        )
+        .delete(synchronize_session=False)
+    )
+
+
 def backfill_org_workspace_memberships(db: Session, *, organization_id: UUID) -> None:
     """Add every org member to every org workspace (idempotent)."""
     roles = seed_system_workspace_roles(db, organization_id=organization_id)

--- a/config.docker.yml
+++ b/config.docker.yml
@@ -21,11 +21,14 @@ operational:
   public: false
   trusted_ips:
     - "10.0.0.0/8"
+  health_rate_limit_per_minute: 60
+  health_readiness_cache_seconds: 10
 
 security:
   csp_enabled: true
   csp_report_only: false
   # public_base_url: "https://sandbox.efficientai.cloud"
+  # Production: trusted_hosts: ["sandbox.efficientai.cloud"] — /health exempt; VPC IPs via operational.trusted_ips
   # trusted_hosts:
   #   - "localhost"
   #   - "efficientai.local"

--- a/config.docker.yml
+++ b/config.docker.yml
@@ -25,6 +25,19 @@ operational:
 security:
   csp_enabled: true
   csp_report_only: false
+  # public_base_url: "https://sandbox.efficientai.cloud"
+  # trusted_hosts:
+  #   - "localhost"
+  #   - "efficientai.local"
+  # hsts_enabled: true
+
+rate_limits:
+  enforce: true
+  auth_per_ip_per_minute: 15
+  resource_create_burst: 100
+  resource_create_burst_window_minutes: 10
+  resource_create_sustained_per_minute: 30
+  resource_create_org_per_hour: 2000
 
 # Database Configuration (Docker service name)
 database:

--- a/config.docker.yml
+++ b/config.docker.yml
@@ -6,7 +6,7 @@ app:
   name: "EfficientAI Voice AI Evaluation Platform"
   version: "0.1.0"
   debug: false
-  secret_key: "your-secret-key-here-change-in-production"
+  secret_key: "${SECRET_KEY}"
   frontend_base_url: "http://localhost:8000"
 
 # Server Settings

--- a/config.yml.example
+++ b/config.yml.example
@@ -29,7 +29,23 @@ operational:
 security:
   csp_enabled: true
   csp_report_only: false   # false = enforcing Content-Security-Policy header (required for compliance scans)
+  # public_base_url: "https://sandbox.efficientai.cloud"
+  # trusted_hosts:
+  #   - "localhost"
+  #   - "127.0.0.1"
+  #   - "sandbox.efficientai.cloud"
+  # hsts_enabled: true
+  # hsts_max_age: 31536000
+  # hsts_include_subdomains: true
   # csp_policy: "default-src 'self'; ..."  # optional override (defaults include Vapi/Daily, Retell/LiveKit, ElevenLabs)
+
+rate_limits:
+  enforce: true
+  auth_per_ip_per_minute: 15
+  resource_create_burst: 100
+  resource_create_burst_window_minutes: 10
+  resource_create_sustained_per_minute: 30
+  resource_create_org_per_hour: 2000
 
 # Database Configuration
 database:
@@ -174,6 +190,11 @@ auth:
     # Keep this short; clients refresh silently via refresh tokens.
     token_ttl_minutes: 15
     refresh_token_ttl_days: 7
+    cookie_session:
+      enabled: true
+      secure: true
+      samesite: lax
+      # domain: ".efficientai.cloud"
     # Turn this off in Cloud SaaS to block self-serve signup.
     allow_signup: true
     # When enabled, signup requires a valid reference code from the platform admin API.

--- a/config.yml.example
+++ b/config.yml.example
@@ -77,6 +77,7 @@ database:
   #   shards   → efficientai_data_01, efficientai_data_02, …
   #   shard id → data-shard-01, data-shard-02, … (labels in config + registry)
   #
+  # Required when sharding.enabled is true in production: auth/RBAC migrations
   # catalog_url: "postgresql://efficientai:password@localhost:5432/efficientai_catalog"
   sharding:
     enabled: false

--- a/config.yml.example
+++ b/config.yml.example
@@ -244,6 +244,14 @@ judge_alignment:
 # license:
 #   key: "eyJhbGciOi..."
 
+# Telephony / recording URL safety (SSRF allowlist for provider recording fetches).
+# Built-in suffixes cover Exotel, Plivo, Vobiz, AWS S3/CloudFront, GCS, Azure Blob,
+# DigitalOcean Spaces, Backblaze B2, Cloudflare R2, Vapi, Retell, ElevenLabs,
+# Daily, LiveKit, and Smallest. Add custom CDN host suffixes below if needed.
+# telephony:
+#   recording_url_allowed_host_suffixes:
+#     - "recordings.mycompany.com"
+
 # Vobiz Telephony (platform-level). Shared account credentials used for
 # inbound/outbound PSTN calls bridged into agent Pipecat pipelines.
 # vobiz:

--- a/config.yml.example
+++ b/config.yml.example
@@ -24,8 +24,8 @@ operational:
   public: false
   trusted_ips:
     - "10.0.0.0/8"
-  # Anonymous /health from the internet: cheap liveness only + per-IP rate limit.
-  # ALB/VPC peers in trusted_ips get full readiness (503 while migrations run).
+  # /health = liveness (always 200 ok) for ALB + internet; rate-limited for public IPs.
+  # /health/ready = readiness (503 while migrations run); VPC/LB peers in trusted_ips only.
   health_rate_limit_per_minute: 60
   health_readiness_cache_seconds: 10
 

--- a/config.yml.example
+++ b/config.yml.example
@@ -24,16 +24,23 @@ operational:
   public: false
   trusted_ips:
     - "10.0.0.0/8"
+  # Anonymous /health from the internet: cheap liveness only + per-IP rate limit.
+  # ALB/VPC peers in trusted_ips get full readiness (503 while migrations run).
+  health_rate_limit_per_minute: 60
+  health_readiness_cache_seconds: 10
 
 # HTTP security headers (CSP, X-Frame-Options, etc.)
 security:
   csp_enabled: true
   csp_report_only: false   # false = enforcing Content-Security-Policy header (required for compliance scans)
   # public_base_url: "https://sandbox.efficientai.cloud"
+  # Production: list your public hostname only. /health is exempt from Host checks;
+  # ALB/kube probes that send a VPC IP as Host are allowed via operational.trusted_ips.
   # trusted_hosts:
+  #   - "sandbox.efficientai.cloud"
+  # Local dev (optional):
   #   - "localhost"
   #   - "127.0.0.1"
-  #   - "sandbox.efficientai.cloud"
   # hsts_enabled: true
   # hsts_max_age: 31536000
   # hsts_include_subdomains: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,9 +16,8 @@ services:
       POSTGRES_DB: ${POSTGRES_DB:-efficientai}
     volumes:
       - postgres_data:/var/lib/postgresql/data
-      # Optional: generic catalog + data DBs for sharding tests (first init only):
-      # - ./docker/postgres/init-sharding-dbs.sh:/docker-entrypoint-initdb.d/02-init-sharding-dbs.sh:ro
-      # See config.docker.sharding.example.yml
+      # Creates efficientai_data_01/02/03 on first volume init (catalog stays POSTGRES_DB):
+      - ./docker/postgres/init-sharding-dbs.sh:/docker-entrypoint-initdb.d/02-init-sharding-dbs.sh:ro
     ports:
       - "5432:5432"
     healthcheck:

--- a/env.example
+++ b/env.example
@@ -57,6 +57,18 @@ AUTH_PROVIDERS=["api_key","local_password"]
 AUTH_LOCAL_TOKEN_TTL_MINUTES=15
 AUTH_REFRESH_TOKEN_TTL_DAYS=7
 AUTH_LOCAL_ALLOW_SIGNUP=true
+# Browser sessions use httpOnly cookies (eai_access/eai_refresh) + CSRF (eai_csrf).
+# AUTH_COOKIE_SESSION_ENABLED=true
+# AUTH_COOKIE_SECURE=true
+# AUTH_COOKIE_SAMESITE=lax
+
+# Production deploy (Phase C — set before go-live):
+# SECRET_KEY=<64+ char random, rotate on deploy>
+# DEBUG=false
+# security.trusted_hosts in config.yml
+# security.public_base_url in config.yml
+# security.hsts_enabled: true
+# ALB listener policy: ELBSecurityPolicy-TLS13-1-2-2021-06
 
 # External OIDC (requires an EFFICIENTAI_LICENSE with feature "oidc_sso")
 # Works with any OIDC-compliant IdP: Okta, Azure AD / Entra ID,

--- a/env.example
+++ b/env.example
@@ -72,7 +72,9 @@ AUTH_LOCAL_ALLOW_SIGNUP=true
 # Production deploy (Phase C — set before go-live):
 # SECRET_KEY=<64+ char random, rotate on deploy>
 # DEBUG=false
-# security.trusted_hosts in config.yml
+# security.trusted_hosts in config.yml — e.g. ["sandbox.efficientai.cloud"] (no "*" needed)
+# operational.trusted_ips in config.yml — VPC CIDR for /metrics + ALB readiness /health
+# operational.health_rate_limit_per_minute — caps anonymous /health abuse (LB peers exempt)
 # security.public_base_url in config.yml
 # security.hsts_enabled: true
 # ALB listener policy: ELBSecurityPolicy-TLS13-1-2-2021-06

--- a/env.example
+++ b/env.example
@@ -62,6 +62,13 @@ AUTH_LOCAL_ALLOW_SIGNUP=true
 # AUTH_COOKIE_SECURE=true
 # AUTH_COOKIE_SAMESITE=lax
 
+# Recording URL SSRF allowlist (optional extras merged onto built-in defaults).
+# Built-in suffixes include: exotel.com, plivo.com, vobiz.ai, amazonaws.com,
+# cloudfront.net, googleapis.com, blob.core.windows.net, digitaloceanspaces.com,
+# backblazeb2.com, r2.cloudflarestorage.com, vapi.ai, retell.ai, elevenlabs.io,
+# daily.co, livekit.cloud, smallest.ai
+# RECORDING_URL_ALLOWED_HOST_SUFFIXES=["recordings.mycompany.com"]
+
 # Production deploy (Phase C — set before go-live):
 # SECRET_KEY=<64+ char random, rotate on deploy>
 # DEBUG=false

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,5 @@
-import { BrowserRouter, Routes, Route, Navigate, useParams } from 'react-router-dom'
+import { useEffect, useState } from 'react'
+import { BrowserRouter, Routes, Route, Navigate, useParams, useLocation } from 'react-router-dom'
 import { useAuthStore } from './store/authStore'
 import { useLicenseStore } from './store/licenseStore'
 import Layout from './components/Layout'
@@ -61,8 +62,9 @@ import EvaluationsList from './pages/evaluators/results/EvaluationsList'
 
 // Observability
 import Observability from './pages/observability/Observability'
-import ObservabilityCalls from './pages/observability/ObservabilityCalls'
 import ObservabilityCallDetail from './pages/observability/ObservabilityCallDetail'
+import TestInsights from './pages/test-insights/TestInsights'
+import CallTraceDetail from './pages/test-insights/CallTraceDetail'
 
 // Alerting
 import Alerts from './pages/alerting/Alerts'
@@ -105,13 +107,34 @@ import CallImportTagsPage from './pages/callImports/Tags'
 import CallImportSchemasPage from './pages/callImports/Schemas'
 
 
-function PrivateRoute({ children }: { children: React.ReactNode }) {
-  // Either credential type counts as "signed in". The backend enforces the
-  // actual authentication on every request; this guard just keeps the SPA
-  // from flashing protected pages when the user clearly has no session.
-  const { apiKey, accessToken } = useAuthStore()
+function PreserveSearchRedirect({ to }: { to: string }) {
+  const location = useLocation()
+  return <Navigate to={`${to}${location.search}`} replace />
+}
 
-  if (!apiKey && !accessToken) {
+function PrivateRoute({ children }: { children: React.ReactNode }) {
+  const { apiKey, user, sessionReady, bootstrapSession } = useAuthStore()
+  const [bootstrapping, setBootstrapping] = useState(!sessionReady)
+
+  useEffect(() => {
+    let active = true
+    bootstrapSession().finally(() => {
+      if (active) setBootstrapping(false)
+    })
+    return () => {
+      active = false
+    }
+  }, [bootstrapSession, sessionReady])
+
+  if (bootstrapping || !sessionReady) {
+    return (
+      <div className="flex items-center justify-center h-screen">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900" />
+      </div>
+    )
+  }
+
+  if (!apiKey && !user) {
     return <Navigate to="/login" replace />
   }
 
@@ -194,8 +217,13 @@ function App() {
           />
           <Route path="results/:id" element={<EvaluatorResultDetail />} />
           <Route path="observability" element={<Observability />} />
-          <Route path="observability/calls" element={<ObservabilityCalls />} />
+          <Route path="observability/calls" element={<TestInsights />} />
           <Route path="observability/calls/:callShortId" element={<ObservabilityCallDetail />} />
+          <Route path="calls" element={<PreserveSearchRedirect to="/observability/calls" />} />
+          <Route path="calls/:traceId" element={<CallTraceDetail />} />
+          <Route path="call-traces" element={<Navigate to="/observability/calls" replace />} />
+          <Route path="call-traces/:traceId" element={<CallTraceDetail />} />
+          <Route path="test-insights" element={<PreserveSearchRedirect to="/observability/calls" />} />
           <Route path="iam" element={<IAM />} />
           <Route path="usage" element={<UsagePage />} />
           <Route path="usage/pricing" element={<UsagePricingRedirect />} />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { BrowserRouter, Routes, Route, Navigate, useParams, useLocation } from 'react-router-dom'
+import { BrowserRouter, Routes, Route, Navigate, useParams } from 'react-router-dom'
 import { useAuthStore } from './store/authStore'
 import { useLicenseStore } from './store/licenseStore'
 import Layout from './components/Layout'
@@ -62,9 +62,8 @@ import EvaluationsList from './pages/evaluators/results/EvaluationsList'
 
 // Observability
 import Observability from './pages/observability/Observability'
+import ObservabilityCalls from './pages/observability/ObservabilityCalls'
 import ObservabilityCallDetail from './pages/observability/ObservabilityCallDetail'
-import TestInsights from './pages/test-insights/TestInsights'
-import CallTraceDetail from './pages/test-insights/CallTraceDetail'
 
 // Alerting
 import Alerts from './pages/alerting/Alerts'
@@ -106,11 +105,6 @@ import CallImportEvaluationDetail from './pages/callImports/CallImportEvaluation
 import CallImportTagsPage from './pages/callImports/Tags'
 import CallImportSchemasPage from './pages/callImports/Schemas'
 
-
-function PreserveSearchRedirect({ to }: { to: string }) {
-  const location = useLocation()
-  return <Navigate to={`${to}${location.search}`} replace />
-}
 
 function PrivateRoute({ children }: { children: React.ReactNode }) {
   const { apiKey, user, sessionReady, bootstrapSession } = useAuthStore()
@@ -217,13 +211,8 @@ function App() {
           />
           <Route path="results/:id" element={<EvaluatorResultDetail />} />
           <Route path="observability" element={<Observability />} />
-          <Route path="observability/calls" element={<TestInsights />} />
+          <Route path="observability/calls" element={<ObservabilityCalls />} />
           <Route path="observability/calls/:callShortId" element={<ObservabilityCallDetail />} />
-          <Route path="calls" element={<PreserveSearchRedirect to="/observability/calls" />} />
-          <Route path="calls/:traceId" element={<CallTraceDetail />} />
-          <Route path="call-traces" element={<Navigate to="/observability/calls" replace />} />
-          <Route path="call-traces/:traceId" element={<CallTraceDetail />} />
-          <Route path="test-insights" element={<PreserveSearchRedirect to="/observability/calls" />} />
           <Route path="iam" element={<IAM />} />
           <Route path="usage" element={<UsagePage />} />
           <Route path="usage/pricing" element={<UsagePricingRedirect />} />

--- a/frontend/src/components/ConfirmModal.tsx
+++ b/frontend/src/components/ConfirmModal.tsx
@@ -1,9 +1,11 @@
+import type { ReactNode } from 'react'
 import { AlertTriangle } from 'lucide-react'
 import Button from './Button'
 
 interface ConfirmModalProps {
   title: string
-  description?: string
+  description?: ReactNode
+  children?: ReactNode
   confirmLabel?: string
   cancelLabel?: string
   isOpen: boolean
@@ -16,6 +18,7 @@ interface ConfirmModalProps {
 export default function ConfirmModal({
   title,
   description,
+  children,
   confirmLabel = 'Confirm',
   cancelLabel = 'Cancel',
   isOpen,
@@ -74,9 +77,16 @@ export default function ConfirmModal({
           </div>
           
           {/* Body */}
-          {description && (
-            <div className="mb-6">
-              <p className="text-gray-600">{description}</p>
+          {(description || children) && (
+            <div className="mb-6 space-y-3 text-sm text-gray-600">
+              {description && (
+                typeof description === 'string' ? (
+                  <p>{description}</p>
+                ) : (
+                  description
+                )
+              )}
+              {children}
             </div>
           )}
           

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -39,7 +39,9 @@ import {
   Upload,
 } from 'lucide-react'
 import { useState, useEffect } from 'react'
+import { Info, X } from 'lucide-react'
 import Logo from './Logo'
+import { consumeJoinNotice } from '../lib/joinNotice'
 import WorkspaceSwitcher from './WorkspaceSwitcher'
 import WalkthroughRail from './walkthrough/WalkthroughRail'
 
@@ -213,6 +215,12 @@ export default function Layout() {
     }
   }, [agents, agentsLoaded, isInitialized, selectedAgent, setSelectedAgent])
 
+  const [joinNotice, setJoinNotice] = useState<string | null>(null)
+
+  useEffect(() => {
+    setJoinNotice(consumeJoinNotice())
+  }, [])
+
   return (
     <div className="min-h-screen bg-gray-50">
       {/* Mobile sidebar */}
@@ -382,6 +390,23 @@ export default function Layout() {
 
         {/* Page content */}
         <main className="flex-1 p-6 transition-all duration-300">
+          {joinNotice && (
+            <div
+              role="status"
+              className="mb-4 flex items-start gap-3 rounded-xl border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-900"
+            >
+              <Info className="mt-0.5 h-4 w-4 flex-shrink-0 text-blue-600" />
+              <p className="min-w-0 flex-1 leading-relaxed">{joinNotice}</p>
+              <button
+                type="button"
+                onClick={() => setJoinNotice(null)}
+                className="flex-shrink-0 text-blue-500 hover:text-blue-700"
+                aria-label="Dismiss"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+          )}
           <div className="min-h-[calc(100vh-7rem)] min-w-0">
             <Outlet />
           </div>

--- a/frontend/src/components/OrgReauthModal.tsx
+++ b/frontend/src/components/OrgReauthModal.tsx
@@ -9,7 +9,7 @@ type OrgReauthModalProps = {
   isLoading?: boolean
   error?: string
   onClose: () => void
-  onSubmit: (password: string) => Promise<void>
+  onSubmit: (password: string) => Promise<unknown>
 }
 
 export default function OrgReauthModal({

--- a/frontend/src/components/OrgReauthModal.tsx
+++ b/frontend/src/components/OrgReauthModal.tsx
@@ -1,0 +1,133 @@
+import { useEffect, useState } from 'react'
+import { Building2, Eye, EyeOff, Loader2, X } from 'lucide-react'
+import Button from './Button'
+
+type OrgReauthModalProps = {
+  open: boolean
+  organizationName: string
+  email?: string | null
+  isLoading?: boolean
+  error?: string
+  onClose: () => void
+  onSubmit: (password: string) => Promise<void>
+}
+
+export default function OrgReauthModal({
+  open,
+  organizationName,
+  email,
+  isLoading = false,
+  error = '',
+  onClose,
+  onSubmit,
+}: OrgReauthModalProps) {
+  const [password, setPassword] = useState('')
+  const [showPassword, setShowPassword] = useState(false)
+
+  useEffect(() => {
+    if (!open) {
+      setPassword('')
+      setShowPassword(false)
+    }
+  }, [open])
+
+  if (!open) return null
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    await onSubmit(password)
+  }
+
+  const handleClose = () => {
+    if (isLoading) return
+    setPassword('')
+    setShowPassword(false)
+    onClose()
+  }
+
+  return (
+    <div className="fixed inset-0 z-[60] overflow-y-auto">
+      <div className="flex min-h-screen items-center justify-center p-4">
+        <div className="fixed inset-0 bg-gray-500/75 transition-opacity" onClick={handleClose} />
+        <div className="relative bg-white rounded-2xl shadow-xl max-w-md w-full p-6">
+          <button
+            type="button"
+            onClick={handleClose}
+            disabled={isLoading}
+            className="absolute right-4 top-4 text-gray-400 hover:text-gray-600 disabled:opacity-50"
+            aria-label="Close"
+          >
+            <X className="h-5 w-5" />
+          </button>
+
+          <div className="flex items-center gap-3 mb-2">
+            <div className="p-2.5 rounded-full bg-[#fef9c3]">
+              <Building2 className="w-5 h-5 text-[#ca8a04]" />
+            </div>
+            <h3 className="text-lg font-semibold text-gray-900 pr-8">Sign in to switch</h3>
+          </div>
+
+          <p className="text-sm text-gray-600 mb-5">
+            Enter the password for <span className="font-medium text-gray-900">{organizationName}</span>
+            {email ? (
+              <>
+                {' '}
+                as <span className="font-medium text-gray-900">{email}</span>
+              </>
+            ) : null}
+            .
+          </p>
+
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="relative">
+              <input
+                type={showPassword ? 'text' : 'password'}
+                placeholder="Organization password"
+                autoComplete="current-password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                disabled={isLoading}
+                className="w-full px-4 py-3 pr-12 text-base text-gray-900 bg-gray-50 border-2 border-gray-200 rounded-xl focus:outline-none focus:border-[#ca8a04] focus:bg-white disabled:opacity-60"
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword((v) => !v)}
+                className="absolute inset-y-0 right-0 px-4 flex items-center text-gray-400 hover:text-gray-600"
+                aria-label={showPassword ? 'Hide password' : 'Show password'}
+              >
+                {showPassword ? <EyeOff className="h-5 w-5" /> : <Eye className="h-5 w-5" />}
+              </button>
+            </div>
+
+            {error && (
+              <p className="text-sm text-red-700 bg-red-50 border border-red-100 rounded-lg px-3 py-2">
+                {error}
+              </p>
+            )}
+
+            <div className="flex justify-end gap-3 pt-1">
+              <Button type="button" variant="ghost" onClick={handleClose} disabled={isLoading}>
+                Cancel
+              </Button>
+              <button
+                type="submit"
+                disabled={isLoading || !password}
+                className="px-4 py-2 rounded-full font-semibold transition-colors disabled:opacity-50 bg-[#fef9c3] hover:bg-[#fef08a] text-[#a16207] border border-[#facc15]"
+              >
+                {isLoading ? (
+                  <span className="flex items-center gap-2">
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    Signing in
+                  </span>
+                ) : (
+                  'Continue'
+                )}
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/OrgSwitcher.tsx
+++ b/frontend/src/components/OrgSwitcher.tsx
@@ -115,7 +115,9 @@ export default function OrgSwitcher() {
         isLoading={reauthLoading}
         error={reauthError}
         onClose={closeReauth}
-        onSubmit={submitReauth}
+        onSubmit={async (password) => {
+          await submitReauth(password)
+        }}
       />
     </>
   )

--- a/frontend/src/components/OrgSwitcher.tsx
+++ b/frontend/src/components/OrgSwitcher.tsx
@@ -18,7 +18,7 @@ import type { Profile } from '../types/api'
  * all react-query caches so every view refetches against the new tenant.
  */
 export default function OrgSwitcher() {
-  const { accessToken, user, switchOrg } = useAuthStore()
+  const { apiKey, user, switchOrg } = useAuthStore()
   const queryClient = useQueryClient()
   const [open, setOpen] = useState(false)
   const [switchingTo, setSwitchingTo] = useState<string | null>(null)
@@ -27,12 +27,12 @@ export default function OrgSwitcher() {
   const { data: profile } = useQuery<Profile>({
     queryKey: ['profile'],
     queryFn: () => apiClient.getProfile(),
-    enabled: !!accessToken,
+    enabled: !!user && !apiKey,
   })
 
   // Hide entirely for API-key sessions or single-org users - no switching
   // makes sense there, and the clutter isn't worth it.
-  if (!accessToken) return null
+  if (!user || apiKey) return null
   const orgs = profile?.organizations ?? []
   if (orgs.length <= 1) return null
 

--- a/frontend/src/components/OrgSwitcher.tsx
+++ b/frontend/src/components/OrgSwitcher.tsx
@@ -1,28 +1,26 @@
 import { useState } from 'react'
-import { useQuery, useQueryClient } from '@tanstack/react-query'
+import { useQuery } from '@tanstack/react-query'
 import { Building2, Check, ChevronDown, Loader2 } from 'lucide-react'
 import { apiClient } from '../lib/api'
 import { useAuthStore } from '../store/authStore'
+import { useOrgSwitch } from '../hooks/useOrgSwitch'
+import OrgReauthModal from './OrgReauthModal'
 import type { Profile } from '../types/api'
 
-/**
- * Organization switcher dropdown.
- *
- * Shown only when:
- *   - The user has a Bearer session (API keys are per-tenant by design and
- *     can't switch orgs).
- *   - The user is a member of more than one organization.
- *
- * On selection, calls POST /auth/switch-org which returns a new Bearer token
- * pinned to the target org. We swap it into the auth store and invalidate
- * all react-query caches so every view refetches against the new tenant.
- */
 export default function OrgSwitcher() {
-  const { apiKey, user, switchOrg } = useAuthStore()
-  const queryClient = useQueryClient()
+  const { apiKey, user } = useAuthStore()
+  const {
+    switchingTo,
+    error,
+    reauthTarget,
+    reauthError,
+    reauthLoading,
+    switchToOrg,
+    closeReauth,
+    submitReauth,
+    user: authUser,
+  } = useOrgSwitch()
   const [open, setOpen] = useState(false)
-  const [switchingTo, setSwitchingTo] = useState<string | null>(null)
-  const [error, setError] = useState<string>('')
 
   const { data: profile } = useQuery<Profile>({
     queryKey: ['profile'],
@@ -30,8 +28,6 @@ export default function OrgSwitcher() {
     enabled: !!user && !apiKey,
   })
 
-  // Hide entirely for API-key sessions or single-org users - no switching
-  // makes sense there, and the clutter isn't worth it.
   if (!user || apiKey) return null
   const orgs = profile?.organizations ?? []
   if (orgs.length <= 1) return null
@@ -39,86 +35,88 @@ export default function OrgSwitcher() {
   const currentOrgId = user?.organization_id
   const currentOrg = orgs.find((o) => o.id === currentOrgId) ?? orgs[0]
 
-  const handleSwitch = async (orgId: string) => {
+  const handleSwitch = async (orgId: string, orgName: string) => {
     if (orgId === currentOrgId) {
       setOpen(false)
       return
     }
-    setError('')
-    setSwitchingTo(orgId)
-    try {
-      await switchOrg(orgId)
-      // Blow away every cached query so the UI refetches against the new
-      // tenant. Individual pages read org-scoped data and we don't want
-      // any stale rows from the old org leaking through.
-      await queryClient.invalidateQueries()
+    const switched = await switchToOrg(orgId, orgName)
+    if (switched) {
       setOpen(false)
-    } catch (err: any) {
-      setError(err?.response?.data?.detail || 'Could not switch organization')
-    } finally {
-      setSwitchingTo(null)
     }
   }
 
   return (
-    <div className="relative">
-      <button
-        type="button"
-        onClick={() => setOpen((v) => !v)}
-        className="flex items-center gap-2 px-3 py-1.5 text-sm font-medium text-gray-700 bg-white border border-gray-200 rounded-lg hover:bg-gray-50 hover:border-gray-300 transition-all shadow-sm max-w-[220px]"
-        title="Switch organization"
-      >
-        <Building2 className="h-4 w-4 text-gray-500 flex-shrink-0" />
-        <span className="truncate">{currentOrg?.name ?? 'Organization'}</span>
-        <ChevronDown className="h-4 w-4 text-gray-500 flex-shrink-0" />
-      </button>
+    <>
+      <div className="relative">
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          className="flex items-center gap-2 px-3 py-1.5 text-sm font-medium text-gray-700 bg-white border border-gray-200 rounded-lg hover:bg-gray-50 hover:border-gray-300 transition-all shadow-sm max-w-[220px]"
+          title="Switch organization"
+        >
+          <Building2 className="h-4 w-4 text-gray-500 flex-shrink-0" />
+          <span className="truncate">{currentOrg?.name ?? 'Organization'}</span>
+          <ChevronDown className="h-4 w-4 text-gray-500 flex-shrink-0" />
+        </button>
 
-      {open && (
-        <>
-          <div className="fixed inset-0 z-10" onClick={() => setOpen(false)} />
-          <div className="absolute right-0 mt-2 w-72 bg-white rounded-lg shadow-lg border border-gray-200 z-20">
-            <div className="px-4 py-2 border-b border-gray-100 text-xs font-semibold text-gray-500 uppercase tracking-wide">
-              Your organizations
-            </div>
-            <div className="max-h-80 overflow-y-auto py-1">
-              {orgs.map((org) => {
-                const isCurrent = org.id === currentOrgId
-                const isSwitching = switchingTo === org.id
-                return (
-                  <button
-                    key={org.id}
-                    type="button"
-                    disabled={isSwitching}
-                    onClick={() => handleSwitch(org.id)}
-                    className={`w-full px-4 py-2.5 text-left hover:bg-gray-50 transition-colors flex items-center justify-between gap-2 ${
-                      isCurrent ? 'bg-primary-50' : ''
-                    } disabled:opacity-60`}
-                  >
-                    <div className="min-w-0 flex-1">
-                      <div className="text-sm font-medium text-gray-900 truncate">
-                        {org.name}
-                      </div>
-                      <div className="text-xs text-gray-500 capitalize">
-                        {org.role}
-                      </div>
-                    </div>
-                    {isSwitching ? (
-                      <Loader2 className="h-4 w-4 text-gray-400 animate-spin flex-shrink-0" />
-                    ) : isCurrent ? (
-                      <Check className="h-4 w-4 text-primary-600 flex-shrink-0" />
-                    ) : null}
-                  </button>
-                )
-              })}
-            </div>
-            {error && (
-              <div className="px-4 py-2 border-t border-gray-100 text-xs text-red-700 bg-red-50">
-                {error}
+        {open && (
+          <>
+            <div className="fixed inset-0 z-10" onClick={() => setOpen(false)} />
+            <div className="absolute right-0 mt-2 w-72 bg-white rounded-lg shadow-lg border border-gray-200 z-20">
+              <div className="px-4 py-2 border-b border-gray-100 text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                Your organizations
               </div>
-            )}
-          </div>
-        </>
-      )}
-    </div>
+              <div className="max-h-80 overflow-y-auto py-1">
+                {orgs.map((org) => {
+                  const isCurrent = org.id === currentOrgId
+                  const isSwitching = switchingTo === org.id
+                  return (
+                    <button
+                      key={org.id}
+                      type="button"
+                      disabled={!!switchingTo}
+                      onClick={() => handleSwitch(org.id, org.name)}
+                      className={`w-full px-4 py-2.5 text-left hover:bg-gray-50 transition-colors flex items-center justify-between gap-2 ${
+                        isCurrent ? 'bg-primary-50' : ''
+                      } disabled:opacity-60`}
+                    >
+                      <div className="min-w-0 flex-1">
+                        <div className="text-sm font-medium text-gray-900 truncate">
+                          {org.name}
+                        </div>
+                        <div className="text-xs text-gray-500 capitalize">
+                          {org.role}
+                        </div>
+                      </div>
+                      {isSwitching ? (
+                        <Loader2 className="h-4 w-4 text-gray-400 animate-spin flex-shrink-0" />
+                      ) : isCurrent ? (
+                        <Check className="h-4 w-4 text-primary-600 flex-shrink-0" />
+                      ) : null}
+                    </button>
+                  )
+                })}
+              </div>
+              {error && (
+                <div className="px-4 py-2 border-t border-gray-100 text-xs text-red-700 bg-red-50">
+                  {error}
+                </div>
+              )}
+            </div>
+          </>
+        )}
+      </div>
+
+      <OrgReauthModal
+        open={!!reauthTarget}
+        organizationName={reauthTarget?.name ?? ''}
+        email={authUser?.email}
+        isLoading={reauthLoading}
+        error={reauthError}
+        onClose={closeReauth}
+        onSubmit={submitReauth}
+      />
+    </>
   )
 }

--- a/frontend/src/components/VoiceAgent.tsx
+++ b/frontend/src/components/VoiceAgent.tsx
@@ -330,21 +330,14 @@ export default function VoiceAgent({
       // Resolve credentials. The backend `/connect` and websocket endpoints
       // accept either a Bearer access token (email/password / SSO login) or
       // an API key (legacy / machine access). We pass whichever the user has.
-      const accessToken = localStorage.getItem('accessToken')
+      const accessToken = apiClient.getAccessToken()
       const apiKey = localStorage.getItem('apiKey')
-      if (!accessToken && !apiKey) {
+      if (!accessToken && !apiKey && !apiClient.isCookieSessionEnabled()) {
         throw new Error('Not authenticated. Please log in first.')
       }
 
-      if (!customEndpoint) {
-        // Cookies are set as a fallback - we also pass the credential as a
-        // header below, which is more reliable in cross-origin dev setups.
-        if (accessToken) {
-          document.cookie = `access_token=${accessToken}; path=/; SameSite=Lax`
-        }
-        if (apiKey) {
-          document.cookie = `api_key=${apiKey}; path=/; SameSite=Lax`
-        }
+      if (!customEndpoint && apiKey) {
+        document.cookie = `api_key=${apiKey}; path=/; SameSite=Lax`
         log('Auth credentials set for /connect', 'system')
       } else {
         log('Using custom endpoint, skipping backend API cookie flow', 'system')

--- a/frontend/src/components/VoiceAgent.tsx
+++ b/frontend/src/components/VoiceAgent.tsx
@@ -15,6 +15,7 @@ import Button from './Button'
 import VoiceOrb, { VoiceOrbSpeaker } from './VoiceOrb'
 import { useAgentStore } from '../store/agentStore'
 import { apiClient, apiBaseUrl } from '../lib/api'
+import { csrfHeaders } from '../lib/authSession'
 
 interface VoiceAgentProps {
   personaId?: string
@@ -455,7 +456,7 @@ export default function VoiceAgent({
         // Pass credentials via headers in addition to cookies so /connect
         // works even when the API is on a different origin (e.g. dev mode
         // with frontend on :3000 and API on :8000 where cookies aren't shared).
-        const authHeaders = new Headers()
+        const authHeaders = new Headers({ 'Content-Type': 'application/json' })
         if (!customEndpoint) {
           if (accessToken) {
             authHeaders.set('Authorization', `Bearer ${accessToken}`)
@@ -463,10 +464,24 @@ export default function VoiceAgent({
           if (apiKey) {
             authHeaders.set('X-API-Key', apiKey)
           }
+          for (const [name, value] of Object.entries(csrfHeaders())) {
+            authHeaders.set(name, value)
+          }
         }
+        // Pipecat uses raw fetch (not axios); cookie sessions need credentials + CSRF header.
+        const connectEndpoint =
+          !customEndpoint && apiClient.isCookieSessionEnabled()
+            ? new Request(endpointUrl, {
+                method: 'POST',
+                credentials: 'include',
+                mode: 'cors',
+                headers: authHeaders,
+                body: JSON.stringify({}),
+              })
+            : endpointUrl
         await pcClient.startBotAndConnect({
-          endpoint: endpointUrl,
-          headers: authHeaders,
+          endpoint: connectEndpoint,
+          ...(!customEndpoint && connectEndpoint instanceof Request ? {} : { headers: authHeaders }),
         })
         log('✅ Connection established and RTVI handshake complete!', 'system')
       }

--- a/frontend/src/components/VoiceAgent.tsx
+++ b/frontend/src/components/VoiceAgent.tsx
@@ -337,7 +337,7 @@ export default function VoiceAgent({
         throw new Error('Not authenticated. Please log in first.')
       }
 
-      if (!customEndpoint && apiKey) {
+      if (!customEndpoint && apiKey && !apiClient.isCookieSessionEnabled()) {
         document.cookie = `api_key=${apiKey}; path=/; SameSite=Lax`
         log('Auth credentials set for /connect', 'system')
       } else {

--- a/frontend/src/hooks/useOrgSwitch.ts
+++ b/frontend/src/hooks/useOrgSwitch.ts
@@ -1,0 +1,79 @@
+import { useState } from 'react'
+import { useQueryClient } from '@tanstack/react-query'
+import { useAuthStore } from '../store/authStore'
+import { getApiErrorMessage } from '../lib/apiErrors'
+import { isOrgReauthRequired } from '../lib/orgReauth'
+
+type ReauthTarget = {
+  id: string
+  name: string
+}
+
+export function useOrgSwitch() {
+  const { switchOrg, reauthForOrg, user } = useAuthStore()
+  const queryClient = useQueryClient()
+  const [switchingTo, setSwitchingTo] = useState<string | null>(null)
+  const [reauthTarget, setReauthTarget] = useState<ReauthTarget | null>(null)
+  const [reauthError, setReauthError] = useState('')
+  const [reauthLoading, setReauthLoading] = useState(false)
+  const [error, setError] = useState('')
+
+  const switchToOrg = async (orgId: string, orgName?: string) => {
+    setError('')
+    setSwitchingTo(orgId)
+    try {
+      await switchOrg(orgId)
+      await queryClient.invalidateQueries()
+      return true
+    } catch (err: unknown) {
+      if (isOrgReauthRequired(err)) {
+        setReauthTarget({
+          id: orgId,
+          name: orgName || 'this organization',
+        })
+        setReauthError('')
+        return false
+      }
+      setError(getApiErrorMessage(err, 'Could not switch organization'))
+      return false
+    } finally {
+      setSwitchingTo(null)
+    }
+  }
+
+  const closeReauth = () => {
+    if (reauthLoading) return
+    setReauthTarget(null)
+    setReauthError('')
+  }
+
+  const submitReauth = async (password: string) => {
+    if (!reauthTarget) return
+    setReauthError('')
+    setReauthLoading(true)
+    try {
+      await reauthForOrg(reauthTarget.id, password)
+      await queryClient.invalidateQueries()
+      setReauthTarget(null)
+      return true
+    } catch (err: unknown) {
+      setReauthError(getApiErrorMessage(err, 'Invalid password'))
+      return false
+    } finally {
+      setReauthLoading(false)
+    }
+  }
+
+  return {
+    user,
+    switchingTo,
+    error,
+    setError,
+    reauthTarget,
+    reauthError,
+    reauthLoading,
+    switchToOrg,
+    closeReauth,
+    submitReauth,
+  }
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -176,6 +176,7 @@ export interface TokenResponse {
   token_type: string
   expires_in: number
   user: AuthUserSummary
+  join_notice?: string | null
 }
 
 export interface LoginOrgOption {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -562,7 +562,7 @@ class ApiClient {
     })
 
     this.client.interceptors.request.use((config) => {
-      const apiKey = localStorage.getItem('apiKey')
+      const apiKey = this.cookieSessionEnabled ? null : localStorage.getItem('apiKey')
       const workspaceId = localStorage.getItem('activeWorkspaceId')
       if (this.inMemoryAccessToken) {
         config.headers.Authorization = `Bearer ${this.inMemoryAccessToken}`
@@ -876,25 +876,46 @@ class ApiClient {
     return token ? { Authorization: `Bearer ${token}` } : {}
   }
 
+  private platformRequestConfig(
+    method: string,
+    extraHeaders?: Record<string, string>,
+  ): { headers: Record<string, string>; withCredentials: boolean } {
+    const headers: Record<string, string> = {
+      ...this.platformHeaders(),
+      ...extraHeaders,
+    }
+    const methodLower = method.toLowerCase()
+    if (methodLower !== 'get' && methodLower !== 'head' && methodLower !== 'options') {
+      Object.assign(headers, csrfHeaders())
+    }
+    return { headers, withCredentials: true }
+  }
+
   async platformLogin(email: string, password: string): Promise<PlatformTokenResponse> {
     const response = await axios.post(
       `${API_BASE_URL}/api/v1/platform/auth/login`,
       { email, password },
-      { headers: { 'Content-Type': 'application/json' } },
+      {
+        headers: { 'Content-Type': 'application/json' },
+        withCredentials: true,
+      },
     )
     return response.data
   }
 
   async platformLogout(accessToken?: string | null): Promise<{ success: boolean; admin_id: string }> {
     const token = accessToken ?? localStorage.getItem('platformAccessToken')
-    const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      ...csrfHeaders(),
+    }
     if (token) {
       headers.Authorization = `Bearer ${token}`
     }
     const response = await axios.post(
       `${API_BASE_URL}/api/v1/platform/auth/logout`,
       {},
-      { headers },
+      { headers, withCredentials: true },
     )
     return response.data
   }
@@ -914,18 +935,16 @@ class ApiClient {
   }
 
   revokePlatformSessionBestEffort(accessToken?: string | null): void {
-    if (!accessToken) {
-      return
-    }
     void this.platformLogout(accessToken)
       .catch(() => this.platformLogout(accessToken))
       .catch(() => {})
   }
 
   async getPlatformOrganizationStats(): Promise<PlatformOrganizationStats> {
-    const response = await axios.get(`${API_BASE_URL}/api/v1/platform/organizations/stats`, {
-      headers: this.platformHeaders(),
-    })
+    const response = await axios.get(
+      `${API_BASE_URL}/api/v1/platform/organizations/stats`,
+      this.platformRequestConfig('get'),
+    )
     return response.data
   }
 
@@ -936,7 +955,7 @@ class ApiClient {
     is_active?: boolean
   }): Promise<PlatformOrganizationListResponse> {
     const response = await axios.get(`${API_BASE_URL}/api/v1/platform/organizations`, {
-      headers: this.platformHeaders(),
+      ...this.platformRequestConfig('get'),
       params,
     })
     return response.data
@@ -949,7 +968,7 @@ class ApiClient {
     const response = await axios.patch(
       `${API_BASE_URL}/api/v1/platform/organizations/${orgId}`,
       data,
-      { headers: { ...this.platformHeaders(), 'Content-Type': 'application/json' } },
+      this.platformRequestConfig('patch', { 'Content-Type': 'application/json' }),
     )
     return response.data
   }
@@ -960,7 +979,7 @@ class ApiClient {
   ): Promise<PlatformOrgUser[]> {
     const response = await axios.get(
       `${API_BASE_URL}/api/v1/platform/organizations/${orgId}/users`,
-      { headers: this.platformHeaders(), params },
+      { ...this.platformRequestConfig('get'), params },
     )
     return response.data
   }
@@ -973,15 +992,16 @@ class ApiClient {
     const response = await axios.post(
       `${API_BASE_URL}/api/v1/platform/organizations/${orgId}/users/${userId}/reset-password`,
       { new_password: newPassword },
-      { headers: { ...this.platformHeaders(), 'Content-Type': 'application/json' } },
+      this.platformRequestConfig('post', { 'Content-Type': 'application/json' }),
     )
     return response.data
   }
 
   async listPlatformSignupCodes(): Promise<PlatformSignupCode[]> {
-    const response = await axios.get(`${API_BASE_URL}/api/v1/platform/signup-codes`, {
-      headers: this.platformHeaders(),
-    })
+    const response = await axios.get(
+      `${API_BASE_URL}/api/v1/platform/signup-codes`,
+      this.platformRequestConfig('get'),
+    )
     return response.data
   }
 
@@ -991,9 +1011,11 @@ class ApiClient {
     max_uses?: number
     expires_at?: string
   }): Promise<PlatformSignupCode> {
-    const response = await axios.post(`${API_BASE_URL}/api/v1/platform/signup-codes`, data, {
-      headers: { ...this.platformHeaders(), 'Content-Type': 'application/json' },
-    })
+    const response = await axios.post(
+      `${API_BASE_URL}/api/v1/platform/signup-codes`,
+      data,
+      this.platformRequestConfig('post', { 'Content-Type': 'application/json' }),
+    )
     return response.data
   }
 
@@ -1004,7 +1026,7 @@ class ApiClient {
     const response = await axios.patch(
       `${API_BASE_URL}/api/v1/platform/signup-codes/${codeId}`,
       data,
-      { headers: { ...this.platformHeaders(), 'Content-Type': 'application/json' } },
+      this.platformRequestConfig('patch', { 'Content-Type': 'application/json' }),
     )
     return response.data
   }
@@ -1012,7 +1034,7 @@ class ApiClient {
   async deactivatePlatformSignupCode(codeId: string): Promise<PlatformSignupCode> {
     const response = await axios.delete(
       `${API_BASE_URL}/api/v1/platform/signup-codes/${codeId}`,
-      { headers: this.platformHeaders() },
+      this.platformRequestConfig('delete'),
     )
     return response.data
   }
@@ -4251,37 +4273,22 @@ class ApiClient {
     return response.data
   }
 
-  private async resolveEventStreamToken(): Promise<string | null> {
-    if (this.inMemoryAccessToken) {
-      return this.inMemoryAccessToken
-    }
-    if (!this.cookieSessionEnabled) {
-      return null
-    }
-    try {
-      const response = await this.client.get<{ token?: string }>(
-        '/api/v1/auth/event-stream-token',
-      )
-      return response.data.token || null
-    } catch {
-      return null
-    }
-  }
-
-  private async buildAuthenticatedApiUrl(path: string): Promise<string> {
+  private buildAuthenticatedApiUrl(path: string): string {
     const normalizedPath = path.startsWith('/') ? path : `/${path}`
     const configuredBase = (this.client.defaults.baseURL || '').replace(/\/$/, '')
     const url = configuredBase
       ? new URL(`${configuredBase}${normalizedPath}`)
       : new URL(normalizedPath, window.location.origin)
 
-    const apiKey = localStorage.getItem('apiKey')
     const workspaceId = localStorage.getItem('activeWorkspaceId')
-    const accessToken = this.inMemoryAccessToken || (await this.resolveEventStreamToken())
-    if (accessToken) {
-      url.searchParams.set('token', accessToken)
-    } else if (apiKey) {
-      url.searchParams.set('api_key', apiKey)
+    if (!this.cookieSessionEnabled) {
+      const accessToken = this.inMemoryAccessToken
+      const apiKey = localStorage.getItem('apiKey')
+      if (accessToken) {
+        url.searchParams.set('token', accessToken)
+      } else if (apiKey) {
+        url.searchParams.set('api_key', apiKey)
+      }
     }
     if (workspaceId) {
       url.searchParams.set('workspace_id', workspaceId)
@@ -4294,7 +4301,7 @@ class ApiClient {
     return response.data
   }
 
-  async getObservabilityCallLiveEventsUrl(callShortId: string): Promise<string> {
+  getObservabilityCallLiveEventsUrl(callShortId: string): string {
     return this.buildAuthenticatedApiUrl(
       `/api/v1/observability/calls/${callShortId}/live-events`,
     )
@@ -4928,7 +4935,7 @@ class ApiClient {
     return response.data
   }
 
-  async getEvaluatorResultLiveEventsUrl(resultId: string): Promise<string> {
+  getEvaluatorResultLiveEventsUrl(resultId: string): string {
     return this.buildAuthenticatedApiUrl(
       `/api/v1/evaluator-results/${resultId}/live-events`,
     )

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -871,9 +871,13 @@ class ApiClient {
     return response.data
   }
 
-  private platformHeaders() {
+  private platformHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {}
     const token = localStorage.getItem('platformAccessToken')
-    return token ? { Authorization: `Bearer ${token}` } : {}
+    if (token) {
+      headers.Authorization = `Bearer ${token}`
+    }
+    return headers
   }
 
   private platformRequestConfig(

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4081,9 +4081,40 @@ class ApiClient {
     return response.data
   }
 
-  async refreshCallRecording(callShortId: string): Promise<{ message: string }> {
-    const response = await this.client.post(`/api/v1/playground/call-recordings/${callShortId}/refresh`)
+  async refreshCallRecording(
+    callShortId: string,
+    providerCallId?: string | null,
+  ): Promise<{ message: string }> {
+    const response = await this.client.post(
+      `/api/v1/playground/call-recordings/${callShortId}/refresh`,
+      providerCallId ? { provider_call_id: providerCallId } : undefined,
+    )
     return response.data
+  }
+
+  async finalizePlaygroundCallRecording(
+    callShortId: string,
+    providerCallId?: string | null,
+  ): Promise<void> {
+    const maxAttempts = 6
+    for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+      try {
+        await this.refreshCallRecording(callShortId, providerCallId)
+        return
+      } catch (error: unknown) {
+        const axiosError = error as {
+          response?: { status?: number; data?: { detail?: string } }
+        }
+        const status = axiosError.response?.status
+        const detail = String(axiosError.response?.data?.detail || '')
+        const missingProvider =
+          status === 400 && detail.toLowerCase().includes('provider')
+        if (!missingProvider || attempt === maxAttempts - 1) {
+          throw error
+        }
+        await new Promise((resolve) => setTimeout(resolve, 400 * (attempt + 1)))
+      }
+    }
   }
 
   async updateCallRecording(callShortId: string, providerCallId: string): Promise<{ message: string; provider_call_id: string }> {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -26,6 +26,7 @@ import type {
   EvaluationStatus,
   OrganizationMember,
   Invitation,
+  InvitationAcceptResponse,
   InvitationCreate,
   InvitationPreview,
   Profile,
@@ -1830,7 +1831,7 @@ class ApiClient {
     return response.data
   }
 
-  async acceptInvitation(invitationId: string): Promise<MessageResponse> {
+  async acceptInvitation(invitationId: string): Promise<InvitationAcceptResponse> {
     const response = await this.client.post(`/api/v1/profile/invitations/${invitationId}/accept`)
     return response.data
   }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -542,7 +542,7 @@ export const apiBaseUrl =
 
 const API_BASE_URL = apiBaseUrl
 
-let refreshPromise: Promise<string | null> | null = null
+let refreshPromise: Promise<boolean> | null = null
 
 class ApiClient {
   private client: AxiosInstance
@@ -608,7 +608,8 @@ class ApiClient {
           requestUrl.includes('/auth/signup') ||
           requestUrl.includes('/auth/refresh') ||
           requestUrl.includes('/auth/logout') ||
-          requestUrl.includes('/auth/config')
+          requestUrl.includes('/auth/config') ||
+          requestUrl.includes('/auth/password')
 
         const detail = getApiErrorDetail(error)
         if (
@@ -627,9 +628,13 @@ class ApiClient {
         ) {
           if (!isAuthEndpoint) {
             originalRequest._retry = true
-            const newToken = await this.tryRefreshAccessToken()
-            if (newToken) {
-              originalRequest.headers.Authorization = `Bearer ${newToken}`
+            const refreshed = await this.tryRefreshAccessToken()
+            if (refreshed) {
+              if (this.cookieSessionEnabled) {
+                delete originalRequest.headers.Authorization
+              } else if (this.inMemoryAccessToken) {
+                originalRequest.headers.Authorization = `Bearer ${this.inMemoryAccessToken}`
+              }
               return this.client(originalRequest)
             }
           }
@@ -642,9 +647,9 @@ class ApiClient {
     )
   }
 
-  private async tryRefreshAccessToken(): Promise<string | null> {
+  private async tryRefreshAccessToken(): Promise<boolean> {
     if (!this.cookieSessionEnabled && !this.inMemoryRefreshToken) {
-      return null
+      return false
     }
 
     if (!refreshPromise) {
@@ -667,7 +672,10 @@ class ApiClient {
           if (rotatedRefresh) {
             this.setRefreshToken(rotatedRefresh)
           }
-          return (access_token || this.inMemoryAccessToken) as string | null
+          // Cookie sessions return empty tokens in JSON; new credentials are Set-Cookie only.
+          return Boolean(
+            this.cookieSessionEnabled || access_token || this.inMemoryAccessToken,
+          )
         })
         .catch((err) => {
           const refreshDetail = getApiErrorDetail(err)
@@ -679,7 +687,7 @@ class ApiClient {
               organizationAccessDeniedMessage(refreshDetail),
             )
           }
-          return null
+          return false
         })
         .finally(() => {
           refreshPromise = null

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1016,6 +1016,29 @@ class ApiClient {
     return response.data
   }
 
+  async establishOidcSession(oidcAccessToken: string): Promise<TokenResponse> {
+    const response = await axios.post(
+      `${API_BASE_URL}/api/v1/auth/oidc/session`,
+      {},
+      {
+        withCredentials: true,
+        headers: {
+          Authorization: `Bearer ${oidcAccessToken}`,
+          'Content-Type': 'application/json',
+          ...csrfHeaders(),
+        },
+      },
+    )
+    const data = response.data as TokenResponse
+    if (data.access_token) {
+      this.setAccessToken(data.access_token)
+    }
+    if (data.refresh_token) {
+      this.setRefreshToken(data.refresh_token)
+    }
+    return data
+  }
+
   async loginWithPassword(
     email: string,
     password: string,

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,6 +1,7 @@
 import axios, { AxiosInstance } from 'axios'
 import {
   clearAuthSession,
+  csrfHeaders,
   getApiErrorDetail,
   hasRevocableUserCredentials,
   isOrganizationAccessDenied,
@@ -154,6 +155,7 @@ export interface AuthConfigResponse {
   providers: AuthProviderConfig[]
   tier: 'oss' | 'enterprise'
   gated_signup?: boolean
+  cookie_session_enabled?: boolean
 }
 
 export interface AuthUserSummary {
@@ -544,24 +546,24 @@ let refreshPromise: Promise<string | null> | null = null
 
 class ApiClient {
   private client: AxiosInstance
+  private inMemoryAccessToken: string | null = null
+  private inMemoryRefreshToken: string | null = null
+  private cookieSessionEnabled = true
 
   constructor() {
     this.client = axios.create({
       baseURL: API_BASE_URL,
+      withCredentials: true,
       headers: {
         'Content-Type': 'application/json',
       },
     })
 
-    // Add request interceptor to add API key + active workspace to headers.
-    // Workspace selection is read directly from localStorage to avoid a
-    // circular import between this module and the workspace store.
     this.client.interceptors.request.use((config) => {
-      const accessToken = localStorage.getItem('accessToken')
       const apiKey = localStorage.getItem('apiKey')
       const workspaceId = localStorage.getItem('activeWorkspaceId')
-      if (accessToken) {
-        config.headers.Authorization = `Bearer ${accessToken}`
+      if (this.inMemoryAccessToken) {
+        config.headers.Authorization = `Bearer ${this.inMemoryAccessToken}`
       } else if (config.headers.Authorization) {
         delete config.headers.Authorization
       }
@@ -570,14 +572,14 @@ class ApiClient {
       } else if (config.headers['X-API-Key']) {
         delete config.headers['X-API-Key']
       }
-      // Send X-Workspace-Id so the backend's get_workspace_id dep scopes
-      // listings to the active workspace. When absent (e.g. a brand-new
-      // session that hasn't called listWorkspaces yet) the backend
-      // falls back to the org's Default workspace.
       if (workspaceId) {
         config.headers['X-Workspace-Id'] = workspaceId
       } else if (config.headers['X-Workspace-Id']) {
         delete config.headers['X-Workspace-Id']
+      }
+      const method = (config.method || 'get').toLowerCase()
+      if (method !== 'get' && method !== 'head' && method !== 'options') {
+        Object.assign(config.headers, csrfHeaders())
       }
       return config
     })
@@ -641,8 +643,7 @@ class ApiClient {
   }
 
   private async tryRefreshAccessToken(): Promise<string | null> {
-    const refreshToken = localStorage.getItem('refreshToken')
-    if (!refreshToken) {
+    if (!this.cookieSessionEnabled && !this.inMemoryRefreshToken) {
       return null
     }
 
@@ -650,16 +651,23 @@ class ApiClient {
       refreshPromise = axios
         .post(
           `${API_BASE_URL}/api/v1/auth/refresh`,
-          { refresh_token: refreshToken },
-          { headers: { 'Content-Type': 'application/json' } },
+          this.cookieSessionEnabled
+            ? {}
+            : { refresh_token: this.inMemoryRefreshToken },
+          {
+            withCredentials: true,
+            headers: { 'Content-Type': 'application/json', ...csrfHeaders() },
+          },
         )
         .then((res) => {
           const { access_token, refresh_token: rotatedRefresh } = res.data as TokenResponse
-          this.setAccessToken(access_token)
+          if (access_token) {
+            this.setAccessToken(access_token)
+          }
           if (rotatedRefresh) {
             this.setRefreshToken(rotatedRefresh)
           }
-          return access_token as string
+          return (access_token || this.inMemoryAccessToken) as string | null
         })
         .catch((err) => {
           const refreshDetail = getApiErrorDetail(err)
@@ -689,20 +697,37 @@ class ApiClient {
     localStorage.removeItem('apiKey')
   }
 
+  setCookieSessionEnabled(enabled: boolean) {
+    this.cookieSessionEnabled = enabled
+  }
+
+  isCookieSessionEnabled(): boolean {
+    return this.cookieSessionEnabled
+  }
+
   setAccessToken(accessToken: string) {
-    localStorage.setItem('accessToken', accessToken)
+    this.inMemoryAccessToken = accessToken
   }
 
   clearAccessToken() {
-    localStorage.removeItem('accessToken')
+    this.inMemoryAccessToken = null
   }
 
   setRefreshToken(refreshToken: string) {
-    localStorage.setItem('refreshToken', refreshToken)
+    this.inMemoryRefreshToken = refreshToken
   }
 
   clearRefreshToken() {
-    localStorage.removeItem('refreshToken')
+    this.inMemoryRefreshToken = null
+  }
+
+  clearInMemoryTokens() {
+    this.inMemoryAccessToken = null
+    this.inMemoryRefreshToken = null
+  }
+
+  getAccessToken(): string | null {
+    return this.inMemoryAccessToken
   }
 
   // Workspace endpoints (in-org isolation boundary for call imports + metrics).
@@ -810,6 +835,7 @@ class ApiClient {
   // Auth endpoints
   async getAuthConfig(): Promise<AuthConfigResponse> {
     const response = await this.client.get('/api/v1/auth/config')
+    this.setCookieSessionEnabled(Boolean(response.data.cookie_session_enabled))
     return response.data
   }
 
@@ -1008,8 +1034,11 @@ class ApiClient {
     refreshToken?: string | null,
     credentials?: { accessToken?: string | null; apiKey?: string | null },
   ): Promise<{ success: boolean; auth_method: string }> {
-    const headers: Record<string, string> = { 'Content-Type': 'application/json' }
-    const accessToken = credentials?.accessToken ?? localStorage.getItem('accessToken')
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      ...csrfHeaders(),
+    }
+    const accessToken = credentials?.accessToken ?? this.inMemoryAccessToken
     const apiKey = credentials?.apiKey ?? localStorage.getItem('apiKey')
     if (accessToken) {
       headers.Authorization = `Bearer ${accessToken}`
@@ -1018,19 +1047,25 @@ class ApiClient {
     }
     const response = await axios.post(
       `${API_BASE_URL}/api/v1/auth/logout`,
-      {
-        refresh_token: refreshToken ?? localStorage.getItem('refreshToken') ?? undefined,
-      },
-      { headers },
+      this.cookieSessionEnabled
+        ? {}
+        : {
+            refresh_token:
+              refreshToken ?? this.inMemoryRefreshToken ?? undefined,
+          },
+      { headers, withCredentials: true },
     )
     return response.data
   }
 
-  async refreshSession(refreshToken: string): Promise<TokenResponse> {
+  async refreshSession(refreshToken?: string): Promise<TokenResponse> {
     const response = await axios.post(
       `${API_BASE_URL}/api/v1/auth/refresh`,
-      { refresh_token: refreshToken },
-      { headers: { 'Content-Type': 'application/json' } },
+      this.cookieSessionEnabled ? {} : { refresh_token: refreshToken },
+      {
+        withCredentials: true,
+        headers: { 'Content-Type': 'application/json', ...csrfHeaders() },
+      },
     )
     return response.data
   }
@@ -1043,7 +1078,9 @@ class ApiClient {
   async switchOrganization(organizationId: string): Promise<TokenResponse> {
     const response = await this.client.post('/api/v1/auth/switch-org', {
       organization_id: organizationId,
-      refresh_token: localStorage.getItem('refreshToken') || undefined,
+      ...(this.cookieSessionEnabled
+        ? {}
+        : { refresh_token: this.inMemoryRefreshToken || undefined }),
     })
     return response.data
   }
@@ -4158,7 +4195,7 @@ class ApiClient {
       ? new URL(`${configuredBase}${normalizedPath}`)
       : new URL(normalizedPath, window.location.origin)
 
-    const accessToken = localStorage.getItem('accessToken')
+    const accessToken = this.inMemoryAccessToken
     const apiKey = localStorage.getItem('apiKey')
     const workspaceId = localStorage.getItem('activeWorkspaceId')
     if (accessToken) {

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -626,19 +626,18 @@ class ApiClient {
         if (
           response?.status === 401 &&
           originalRequest &&
-          !originalRequest._retry
+          !originalRequest._retry &&
+          !isAuthEndpoint
         ) {
-          if (!isAuthEndpoint) {
-            originalRequest._retry = true
-            const refreshed = await this.tryRefreshAccessToken()
-            if (refreshed) {
-              if (this.cookieSessionEnabled) {
-                delete originalRequest.headers.Authorization
-              } else if (this.inMemoryAccessToken) {
-                originalRequest.headers.Authorization = `Bearer ${this.inMemoryAccessToken}`
-              }
-              return this.client(originalRequest)
+          originalRequest._retry = true
+          const refreshed = await this.tryRefreshAccessToken()
+          if (refreshed) {
+            if (this.cookieSessionEnabled) {
+              delete originalRequest.headers.Authorization
+            } else if (this.inMemoryAccessToken) {
+              originalRequest.headers.Authorization = `Bearer ${this.inMemoryAccessToken}`
             }
+            return this.client(originalRequest)
           }
 
           clearAuthSession()

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4220,16 +4220,33 @@ class ApiClient {
     return response.data
   }
 
-  private buildAuthenticatedApiUrl(path: string): string {
+  private async resolveEventStreamToken(): Promise<string | null> {
+    if (this.inMemoryAccessToken) {
+      return this.inMemoryAccessToken
+    }
+    if (!this.cookieSessionEnabled) {
+      return null
+    }
+    try {
+      const response = await this.client.get<{ token?: string }>(
+        '/api/v1/auth/event-stream-token',
+      )
+      return response.data.token || null
+    } catch {
+      return null
+    }
+  }
+
+  private async buildAuthenticatedApiUrl(path: string): Promise<string> {
     const normalizedPath = path.startsWith('/') ? path : `/${path}`
     const configuredBase = (this.client.defaults.baseURL || '').replace(/\/$/, '')
     const url = configuredBase
       ? new URL(`${configuredBase}${normalizedPath}`)
       : new URL(normalizedPath, window.location.origin)
 
-    const accessToken = this.inMemoryAccessToken
     const apiKey = localStorage.getItem('apiKey')
     const workspaceId = localStorage.getItem('activeWorkspaceId')
+    const accessToken = this.inMemoryAccessToken || (await this.resolveEventStreamToken())
     if (accessToken) {
       url.searchParams.set('token', accessToken)
     } else if (apiKey) {
@@ -4246,7 +4263,7 @@ class ApiClient {
     return response.data
   }
 
-  getObservabilityCallLiveEventsUrl(callShortId: string): string {
+  async getObservabilityCallLiveEventsUrl(callShortId: string): Promise<string> {
     return this.buildAuthenticatedApiUrl(
       `/api/v1/observability/calls/${callShortId}/live-events`,
     )
@@ -4880,10 +4897,40 @@ class ApiClient {
     return response.data
   }
 
-  getEvaluatorResultLiveEventsUrl(resultId: string): string {
+  async getEvaluatorResultLiveEventsUrl(resultId: string): Promise<string> {
     return this.buildAuthenticatedApiUrl(
       `/api/v1/evaluator-results/${resultId}/live-events`,
     )
+  }
+
+  async listConversationEvaluations(agentId: string): Promise<any[]> {
+    const response = await this.client.get('/api/v1/conversation-evaluations', {
+      params: { agent_id: agentId },
+    })
+    return response.data
+  }
+
+  async createConversationEvaluation(data: {
+    transcription_id: string
+    agent_id: string
+  }): Promise<any> {
+    const response = await this.client.post('/api/v1/conversation-evaluations', data)
+    return response.data
+  }
+
+  async deleteConversationEvaluation(evaluationId: string): Promise<void> {
+    await this.client.delete(`/api/v1/conversation-evaluations/${evaluationId}`)
+  }
+
+  async updateConversationEvaluation(
+    evaluationId: string,
+    data: Record<string, unknown>,
+  ): Promise<any> {
+    const response = await this.client.patch(
+      `/api/v1/conversation-evaluations/${evaluationId}`,
+      data,
+    )
+    return response.data
   }
 
   async getEvaluatorResultMetrics(id: string): Promise<any> {

--- a/frontend/src/lib/authSession.ts
+++ b/frontend/src/lib/authSession.ts
@@ -23,10 +23,25 @@ export function isOrganizationAccessDenied(detail?: string): boolean {
 
 export function clearAuthSession(): void {
   localStorage.removeItem('apiKey')
-  localStorage.removeItem('accessToken')
-  localStorage.removeItem('refreshToken')
   localStorage.removeItem('authUser')
   localStorage.removeItem('activeWorkspaceId')
+  localStorage.removeItem('accessToken')
+  localStorage.removeItem('refreshToken')
+}
+
+export function getCsrfTokenFromCookie(): string | null {
+  if (typeof document === 'undefined') return null
+  for (const part of document.cookie.split(';')) {
+    const trimmed = part.trim()
+    if (!trimmed.startsWith('eai_csrf=')) continue
+    return decodeURIComponent(trimmed.slice('eai_csrf='.length))
+  }
+  return null
+}
+
+export function csrfHeaders(): Record<string, string> {
+  const token = getCsrfTokenFromCookie()
+  return token ? { 'X-CSRF-Token': token } : {}
 }
 
 /** True when a voluntary logout can still revoke something server-side. */

--- a/frontend/src/lib/authSession.ts
+++ b/frontend/src/lib/authSession.ts
@@ -4,6 +4,7 @@ export type UserSessionCredentials = {
   accessToken?: string | null
   refreshToken?: string | null
   apiKey?: string | null
+  cookieSession?: boolean
 }
 
 export function getApiErrorDetail(error: unknown): string | undefined {
@@ -46,7 +47,12 @@ export function csrfHeaders(): Record<string, string> {
 
 /** True when a voluntary logout can still revoke something server-side. */
 export function hasRevocableUserCredentials(credentials: UserSessionCredentials): boolean {
-  return Boolean(credentials.accessToken || credentials.apiKey || credentials.refreshToken)
+  return Boolean(
+    credentials.accessToken ||
+      credentials.apiKey ||
+      credentials.refreshToken ||
+      credentials.cookieSession,
+  )
 }
 
 export function clearPlatformAdminSession(): void {

--- a/frontend/src/lib/joinNotice.ts
+++ b/frontend/src/lib/joinNotice.ts
@@ -1,0 +1,18 @@
+const JOIN_NOTICE_KEY = 'efficientai_join_notice'
+
+export function storeJoinNotice(message: string | null | undefined): void {
+  if (!message?.trim()) return
+  sessionStorage.setItem(JOIN_NOTICE_KEY, message.trim())
+}
+
+export function consumeJoinNotice(): string | null {
+  const message = sessionStorage.getItem(JOIN_NOTICE_KEY)
+  if (message) {
+    sessionStorage.removeItem(JOIN_NOTICE_KEY)
+  }
+  return message
+}
+
+export function clearJoinNotice(): void {
+  sessionStorage.removeItem(JOIN_NOTICE_KEY)
+}

--- a/frontend/src/lib/orgReauth.ts
+++ b/frontend/src/lib/orgReauth.ts
@@ -1,0 +1,23 @@
+import { getApiErrorMessage } from './apiErrors'
+
+export const ORG_REAUTH_DETAIL =
+  'Sign in again with the password for that organization.'
+
+export function isOrgReauthRequired(error: unknown): boolean {
+  const err = error as { response?: { status?: number; data?: { detail?: unknown } } }
+  if (err?.response?.status !== 403) {
+    return false
+  }
+  const detail = err.response?.data?.detail
+  if (typeof detail !== 'string') {
+    return false
+  }
+  return detail.toLowerCase().includes('sign in again')
+}
+
+export function getOrgSwitchErrorMessage(error: unknown, fallback: string): string {
+  if (isOrgReauthRequired(error)) {
+    return ORG_REAUTH_DETAIL
+  }
+  return getApiErrorMessage(error, fallback)
+}

--- a/frontend/src/pages/agents/components/AgentTalkSidebar.tsx
+++ b/frontend/src/pages/agents/components/AgentTalkSidebar.tsx
@@ -60,6 +60,7 @@ export default function AgentTalkSidebar({
   const wasOpenRef = useRef(false)
   const userSpeakingTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const callShortIdRef = useRef<string | null>(null)
+  const providerCallIdRef = useRef<string | null>(null)
 
   const pulseUserSpeaking = (durationMs = 1200) => {
     setActiveSpeaker('user')
@@ -209,6 +210,9 @@ export default function AgentTalkSidebar({
         client.on('call-start', async (call: any) => {
           setIsConnected(true)
           setIsConnecting(false)
+          if (call?.id) {
+            providerCallIdRef.current = call.id
+          }
           if (callShortIdRef.current && call?.id) {
             try {
               await apiClient.updateCallRecording(callShortIdRef.current, call.id)
@@ -232,19 +236,26 @@ export default function AgentTalkSidebar({
             }
           }
         })
-        client.on('call-end', async () => {
+        client.on('call-end', async (call: any) => {
           setIsConnected(false)
           setIsConnecting(false)
           setActiveSpeaker(null)
+          const providerCallId = call?.id ?? providerCallIdRef.current
           if (callShortIdRef.current) {
-            apiClient.refreshCallRecording(callShortIdRef.current).catch((err) => {
-              console.error('Failed to refresh Vapi call recording', err)
-            })
+            apiClient
+              .finalizePlaygroundCallRecording(callShortIdRef.current, providerCallId)
+              .catch((err) => {
+                console.error('Failed to refresh Vapi call recording', err)
+              })
           }
+          providerCallIdRef.current = null
         })
         const webCall = await apiClient.createWebCall({ agent_id: agent.id, metadata: {}, ui_surface: 'agents_talk' })
         callShortIdRef.current = webCall.call_short_id ?? null
         const vapiCall = await client.start(agent.voice_ai_agent_id!)
+        if (vapiCall?.id) {
+          providerCallIdRef.current = vapiCall.id
+        }
         if (callShortIdRef.current && vapiCall?.id) {
           try {
             await apiClient.updateCallRecording(callShortIdRef.current, vapiCall.id)

--- a/frontend/src/pages/agents/components/AgentTalkSidebar.tsx
+++ b/frontend/src/pages/agents/components/AgentTalkSidebar.tsx
@@ -163,6 +163,8 @@ export default function AgentTalkSidebar({
     try {
       if (isRetell) {
         const client = retellClientRef.current!
+        const webCall = await apiClient.createWebCall({ agent_id: agent.id, metadata: {}, ui_surface: 'agents_talk' })
+        callShortIdRef.current = webCall.call_short_id ?? null
         client.on('call_started', () => {
           setIsConnected(true)
           setIsConnecting(false)
@@ -193,13 +195,19 @@ export default function AgentTalkSidebar({
           setIsConnected(false)
           setIsConnecting(false)
           setActiveSpeaker(null)
+          if (callShortIdRef.current) {
+            apiClient
+              .finalizePlaygroundCallRecording(callShortIdRef.current, webCall.call_id)
+              .catch((err) => {
+                console.error('Failed to refresh Retell call recording', err)
+              })
+          }
         })
         client.on('error', () => {
           setIsConnecting(false)
           setIsConnected(false)
           setActiveSpeaker(null)
         })
-        const webCall = await apiClient.createWebCall({ agent_id: agent.id, metadata: {}, ui_surface: 'agents_talk' })
         await client.startCall({
           accessToken: webCall.access_token!,
           callId: webCall.call_id,
@@ -266,6 +274,8 @@ export default function AgentTalkSidebar({
       } else if (isElevenLabs) {
         const webCall = await apiClient.createWebCall({ agent_id: agent.id, metadata: {}, ui_surface: 'agents_talk' })
         if (!webCall.signed_url) throw new Error('No signed URL')
+        callShortIdRef.current = webCall.call_short_id ?? null
+        let elevenLabsConversationIdStored = false
         const conversation = await Conversation.startSession({
           signedUrl: webCall.signed_url,
           onConnect: () => {
@@ -277,6 +287,14 @@ export default function AgentTalkSidebar({
             setIsConnecting(false)
             setActiveSpeaker(null)
             elevenLabsConversationRef.current = null
+            if (callShortIdRef.current && elevenLabsConversationIdStored) {
+              const callShortId = callShortIdRef.current
+              setTimeout(() => {
+                apiClient
+                  .finalizePlaygroundCallRecording(callShortId)
+                  .catch((err) => console.error('Failed to refresh ElevenLabs call recording', err))
+              }, 5000)
+            }
           },
           onModeChange: (mode: { mode?: string }) => {
             if (mode.mode === 'speaking') {
@@ -306,10 +324,20 @@ export default function AgentTalkSidebar({
           },
         })
         elevenLabsConversationRef.current = conversation
+        try {
+          const conversationId = conversation?.getId()
+          if (callShortIdRef.current && conversationId) {
+            await apiClient.updateCallRecording(callShortIdRef.current, conversationId)
+            elevenLabsConversationIdStored = true
+          }
+        } catch (err) {
+          console.error('Failed to update ElevenLabs call recording', err)
+        }
       } else if (isSmallest) {
         const { AtomsClient } = await import('atoms-client-sdk')
         const webCall = await apiClient.createWebCall({ agent_id: agent.id, metadata: {}, ui_surface: 'agents_talk' })
         if (!webCall.access_token || !webCall.host) throw new Error('Missing Smallest credentials')
+        callShortIdRef.current = webCall.call_short_id ?? null
         const client = new AtomsClient()
         smallestClientRef.current = client
         client.on('session_started', () => {
@@ -320,6 +348,14 @@ export default function AgentTalkSidebar({
           setIsConnected(false)
           setIsConnecting(false)
           setActiveSpeaker(null)
+          if (callShortIdRef.current) {
+            const callShortId = callShortIdRef.current
+            setTimeout(() => {
+              apiClient
+                .finalizePlaygroundCallRecording(callShortId)
+                .catch((err) => console.error('Failed to refresh Smallest call recording', err))
+            }, 3000)
+          }
         })
         client.on('transcript', (data: any) => {
           if (data?.text) {

--- a/frontend/src/pages/auth/InviteAccept.tsx
+++ b/frontend/src/pages/auth/InviteAccept.tsx
@@ -11,6 +11,7 @@ import { useAuthStore } from '../../store/authStore'
 import { buildAuthorizeUrl } from '../../lib/oidc'
 import { PASSWORD_POLICY_HINT, validatePasswordPolicy } from '../../lib/passwordPolicy'
 import { storePendingInviteToken } from '../../lib/inviteToken'
+import { storeJoinNotice } from '../../lib/joinNotice'
 
 type Mode = 'signup' | 'password' | 'sso'
 
@@ -123,6 +124,7 @@ export default function InviteAccept() {
       .acceptInvitationByToken(token)
       .then((res) => {
         if (!active) return
+        storeJoinNotice(res.join_notice)
         setSession(
           res.user,
           res.access_token ? { access: res.access_token, refresh: res.refresh_token } : undefined,
@@ -211,6 +213,7 @@ export default function InviteAccept() {
         return
       }
       const accepted = await apiClient.acceptInvitationByToken(token)
+      storeJoinNotice(accepted.join_notice)
       setSession(
         accepted.user,
         accepted.access_token
@@ -273,7 +276,7 @@ export default function InviteAccept() {
 
       <Card className="shadow-xl">
         <CardBody className="p-6">
-          {preview && !previewError && preview.has_password && showAuthForms && (
+          {preview && !previewError && preview.user_exists && showAuthForms && (
             <div className="mb-4 rounded-xl border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-900">
               An account already exists for <span className="font-medium">{preview.email}</span>.
               Sign in below to join {orgName} — you don&apos;t need to create a new account.

--- a/frontend/src/pages/auth/InviteAccept.tsx
+++ b/frontend/src/pages/auth/InviteAccept.tsx
@@ -52,7 +52,7 @@ function InvitePageShell({ children }: { children: React.ReactNode }) {
 export default function InviteAccept() {
   const { token } = useParams<{ token: string }>()
   const navigate = useNavigate()
-  const { user, accessToken, setSession, logout } = useAuthStore()
+  const { user, setSession, logout } = useAuthStore()
 
   const [preview, setPreview] = useState<InvitationPreview | null>(null)
   const [loadingPreview, setLoadingPreview] = useState(true)
@@ -106,7 +106,7 @@ export default function InviteAccept() {
   }, [token])
 
   useEffect(() => {
-    if (!token || !preview || preview.status !== 'pending' || !accessToken || !user) {
+    if (!token || !preview || preview.status !== 'pending' || !user) {
       return
     }
 
@@ -123,7 +123,10 @@ export default function InviteAccept() {
       .acceptInvitationByToken(token)
       .then((res) => {
         if (!active) return
-        setSession(res.access_token, res.user, res.refresh_token)
+        setSession(
+          res.user,
+          res.access_token ? { access: res.access_token, refresh: res.refresh_token } : undefined,
+        )
         navigate('/', { replace: true })
       })
       .catch((err: any) => {
@@ -137,7 +140,7 @@ export default function InviteAccept() {
     return () => {
       active = false
     }
-  }, [token, preview, accessToken, user, setSession, navigate])
+  }, [token, preview, user, setSession, navigate, logout])
 
   const localPwd = authConfig?.providers.find((p) => p.name === 'local_password' && p.enabled)
   const oidc = authConfig?.providers.find((p) => p.name === 'external_oidc' && p.enabled)
@@ -184,7 +187,10 @@ export default function InviteAccept() {
         last_name: lastName || undefined,
         invite_token: token,
       })
-      setSession(res.access_token, res.user, res.refresh_token)
+      setSession(
+        res.user,
+        res.access_token ? { access: res.access_token, refresh: res.refresh_token } : undefined,
+      )
       navigate('/', { replace: true })
     } catch (err: any) {
       setError(err?.response?.data?.detail || 'Sign up failed')
@@ -205,7 +211,12 @@ export default function InviteAccept() {
         return
       }
       const accepted = await apiClient.acceptInvitationByToken(token)
-      setSession(accepted.access_token, accepted.user, accepted.refresh_token)
+      setSession(
+        accepted.user,
+        accepted.access_token
+          ? { access: accepted.access_token, refresh: accepted.refresh_token }
+          : undefined,
+      )
       navigate('/', { replace: true })
     } catch (err: any) {
       setError(err?.response?.data?.detail || 'Sign in failed')
@@ -245,7 +256,7 @@ export default function InviteAccept() {
   const showAuthForms =
     !previewError &&
     preview?.status === 'pending' &&
-    (!accessToken || autoAcceptFailed)
+    (!user || autoAcceptFailed)
 
   return (
     <InvitePageShell>
@@ -283,7 +294,7 @@ export default function InviteAccept() {
 
           {previewError && <FormError message={previewError} />}
 
-          {previewError && accessToken && user && (
+          {previewError && user && (
             <div className="mt-4">
               <Button
                 variant="outline"

--- a/frontend/src/pages/auth/Login.tsx
+++ b/frontend/src/pages/auth/Login.tsx
@@ -12,6 +12,7 @@ import {
   getPendingInviteToken,
   storePendingInviteToken,
 } from '../../lib/inviteToken'
+import { storeJoinNotice } from '../../lib/joinNotice'
 import { AlertCircle, Building2, Eye, EyeOff, Loader2 } from 'lucide-react'
 import Logo from '../../components/Logo'
 import { Card, CardBody, Button, Divider, Tabs, Tab } from '@heroui/react'
@@ -148,6 +149,7 @@ export default function Login() {
       }
       const accepted = await apiClient.acceptInvitationByToken(token)
       consumePendingInviteToken()
+      storeJoinNotice(accepted.join_notice)
       setSession(
         accepted.user,
         accepted.access_token

--- a/frontend/src/pages/auth/Login.tsx
+++ b/frontend/src/pages/auth/Login.tsx
@@ -132,21 +132,31 @@ export default function Login() {
   const localPwd = providerByName('local_password')
   const oidc = providerByName('external_oidc')
 
-  const completeInviteIfNeeded = async (accessToken: string, authUser: Parameters<typeof setSession>[1], refreshToken?: string | null) => {
+  const completeInviteIfNeeded = async (
+    authUser: Parameters<typeof setSession>[0],
+    tokens?: { access?: string; refresh?: string },
+  ) => {
     const token = inviteToken || getPendingInviteToken()
     if (!token) {
-      setSession(accessToken, authUser, refreshToken)
+      setSession(authUser, tokens)
       navigate('/')
       return
     }
     try {
-      apiClient.setAccessToken(accessToken)
+      if (tokens?.access) {
+        apiClient.setAccessToken(tokens.access)
+      }
       const accepted = await apiClient.acceptInvitationByToken(token)
       consumePendingInviteToken()
-      setSession(accepted.access_token, accepted.user, accepted.refresh_token)
+      setSession(
+        accepted.user,
+        accepted.access_token
+          ? { access: accepted.access_token, refresh: accepted.refresh_token }
+          : undefined,
+      )
       navigate('/')
     } catch (err: any) {
-      setSession(accessToken, authUser, refreshToken)
+      setSession(authUser, tokens)
       setError(err?.response?.data?.detail || 'Signed in, but could not accept the invitation')
       navigate('/')
     }
@@ -168,7 +178,10 @@ export default function Login() {
         setLoginStep('org-select')
         return
       }
-      await completeInviteIfNeeded(res.access_token, res.user, res.refresh_token)
+      await completeInviteIfNeeded(
+        res.user,
+        res.access_token ? { access: res.access_token, refresh: res.refresh_token } : undefined,
+      )
     } catch (err: any) {
       setError(err?.response?.data?.detail || 'Invalid email or password')
     } finally {
@@ -190,7 +203,10 @@ export default function Login() {
         setError('Organization selection failed — try again')
         return
       }
-      await completeInviteIfNeeded(res.access_token, res.user, res.refresh_token)
+      await completeInviteIfNeeded(
+        res.user,
+        res.access_token ? { access: res.access_token, refresh: res.refresh_token } : undefined,
+      )
     } catch (err: any) {
       setError(err?.response?.data?.detail || 'Could not sign in to the selected organization')
     } finally {
@@ -218,7 +234,10 @@ export default function Login() {
         invite_token: inviteToken || undefined,
       })
       consumePendingInviteToken()
-      setSession(res.access_token, res.user, res.refresh_token)
+      setSession(
+        res.user,
+        res.access_token ? { access: res.access_token, refresh: res.refresh_token } : undefined,
+      )
       navigate('/')
     } catch (err: unknown) {
       setError(getApiErrorMessage(err, 'Sign up failed'))

--- a/frontend/src/pages/auth/LoginCallback.tsx
+++ b/frontend/src/pages/auth/LoginCallback.tsx
@@ -6,6 +6,7 @@ import { apiClient } from '../../lib/api'
 import { useAuthStore } from '../../store/authStore'
 import { exchangeAuthorizationCode, readPkceState } from '../../lib/oidc'
 import { consumePendingInviteToken, getPendingInviteToken } from '../../lib/inviteToken'
+import { storeJoinNotice } from '../../lib/joinNotice'
 
 export default function LoginCallback() {
   const navigate = useNavigate()
@@ -55,6 +56,7 @@ export default function LoginCallback() {
           try {
             const accepted = await apiClient.acceptInvitationByToken(pendingInvite)
             consumePendingInviteToken()
+            storeJoinNotice(accepted.join_notice)
             setSession(
               accepted.user,
               accepted.access_token

--- a/frontend/src/pages/auth/LoginCallback.tsx
+++ b/frontend/src/pages/auth/LoginCallback.tsx
@@ -56,19 +56,24 @@ export default function LoginCallback() {
           try {
             const accepted = await apiClient.acceptInvitationByToken(pendingInvite)
             consumePendingInviteToken()
-            setSession(accepted.access_token, accepted.user, accepted.refresh_token)
+            setSession(
+              accepted.user,
+              accepted.access_token
+                ? { access: accepted.access_token, refresh: accepted.refresh_token }
+                : undefined,
+            )
             navigate('/', { replace: true })
             return
           } catch (inviteErr: any) {
             if (!active) return
             setError(inviteErr?.response?.data?.detail || 'Signed in, but could not accept the invitation')
-            setSession(accessToken, user)
+            setSession(user, { access: accessToken })
             navigate('/', { replace: true })
             return
           }
         }
 
-        setSession(accessToken, user)
+        setSession(user, { access: accessToken })
 
         const profile = await apiClient.getProfile()
         if (!active) return

--- a/frontend/src/pages/auth/LoginCallback.tsx
+++ b/frontend/src/pages/auth/LoginCallback.tsx
@@ -45,10 +45,9 @@ export default function LoginCallback() {
         }
 
         const redirectUri = `${window.location.origin}/login/callback`
-        const accessToken = await exchangeAuthorizationCode(provider, code, redirectUri)
+        const oidcAccessToken = await exchangeAuthorizationCode(provider, code, redirectUri)
 
-        apiClient.setAccessToken(accessToken)
-        const user = await apiClient.getMe()
+        const session = await apiClient.establishOidcSession(oidcAccessToken)
         if (!active) return
 
         const pendingInvite = getPendingInviteToken()
@@ -67,13 +66,23 @@ export default function LoginCallback() {
           } catch (inviteErr: any) {
             if (!active) return
             setError(inviteErr?.response?.data?.detail || 'Signed in, but could not accept the invitation')
-            setSession(user, { access: accessToken })
+            setSession(
+              session.user,
+              session.access_token
+                ? { access: session.access_token, refresh: session.refresh_token }
+                : undefined,
+            )
             navigate('/', { replace: true })
             return
           }
         }
 
-        setSession(user, { access: accessToken })
+        setSession(
+          session.user,
+          session.access_token
+            ? { access: session.access_token, refresh: session.refresh_token }
+            : undefined,
+        )
 
         const profile = await apiClient.getProfile()
         if (!active) return

--- a/frontend/src/pages/auth/SelectOrganization.tsx
+++ b/frontend/src/pages/auth/SelectOrganization.tsx
@@ -1,18 +1,27 @@
-import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import { Building2, Loader2 } from 'lucide-react'
 import Logo from '../../components/Logo'
 import { Card, CardBody } from '@heroui/react'
 import { apiClient } from '../../lib/api'
-import { getApiErrorMessage } from '../../lib/apiErrors'
 import { useAuthStore } from '../../store/authStore'
+import { useOrgSwitch } from '../../hooks/useOrgSwitch'
+import OrgReauthModal from '../../components/OrgReauthModal'
 
 export default function SelectOrganization() {
   const navigate = useNavigate()
-  const { apiKey, user, switchOrg } = useAuthStore()
-  const [switchingTo, setSwitchingTo] = useState<string | null>(null)
-  const [error, setError] = useState('')
+  const { apiKey, user } = useAuthStore()
+  const {
+    switchingTo,
+    error,
+    reauthTarget,
+    reauthError,
+    reauthLoading,
+    switchToOrg,
+    closeReauth,
+    submitReauth,
+    user: authUser,
+  } = useOrgSwitch()
 
   const { data: profile, isLoading } = useQuery({
     queryKey: ['profile'],
@@ -27,16 +36,17 @@ export default function SelectOrganization() {
 
   const orgs = profile?.organizations ?? []
 
-  const handleSelect = async (orgId: string) => {
-    setError('')
-    setSwitchingTo(orgId)
-    try {
-      await switchOrg(orgId)
+  const handleSelect = async (orgId: string, orgName: string) => {
+    const switched = await switchToOrg(orgId, orgName)
+    if (switched) {
       navigate('/', { replace: true })
-    } catch (err: unknown) {
-      setError(getApiErrorMessage(err, 'Could not enter the selected organization'))
-    } finally {
-      setSwitchingTo(null)
+    }
+  }
+
+  const handleReauthSuccess = async (password: string) => {
+    const ok = await submitReauth(password)
+    if (ok) {
+      navigate('/', { replace: true })
     }
   }
 
@@ -69,7 +79,7 @@ export default function SelectOrganization() {
                       key={org.id}
                       type="button"
                       disabled={!!switchingTo}
-                      onClick={() => handleSelect(org.id)}
+                      onClick={() => handleSelect(org.id, org.name)}
                       className="w-full px-4 py-3 text-left border border-gray-200 rounded-xl hover:bg-gray-50 transition-colors flex items-center gap-3 disabled:opacity-60"
                     >
                       <Building2 className="h-5 w-5 text-gray-500 flex-shrink-0" />
@@ -93,6 +103,16 @@ export default function SelectOrganization() {
           </CardBody>
         </Card>
       </div>
+
+      <OrgReauthModal
+        open={!!reauthTarget}
+        organizationName={reauthTarget?.name ?? ''}
+        email={authUser?.email}
+        isLoading={reauthLoading}
+        error={reauthError}
+        onClose={closeReauth}
+        onSubmit={handleReauthSuccess}
+      />
     </div>
   )
 }

--- a/frontend/src/pages/auth/SelectOrganization.tsx
+++ b/frontend/src/pages/auth/SelectOrganization.tsx
@@ -10,17 +10,17 @@ import { useAuthStore } from '../../store/authStore'
 
 export default function SelectOrganization() {
   const navigate = useNavigate()
-  const { accessToken, switchOrg } = useAuthStore()
+  const { apiKey, user, switchOrg } = useAuthStore()
   const [switchingTo, setSwitchingTo] = useState<string | null>(null)
   const [error, setError] = useState('')
 
   const { data: profile, isLoading } = useQuery({
     queryKey: ['profile'],
     queryFn: () => apiClient.getProfile(),
-    enabled: !!accessToken,
+    enabled: !!user && !apiKey,
   })
 
-  if (!accessToken) {
+  if (!user || apiKey) {
     navigate('/login', { replace: true })
     return null
   }

--- a/frontend/src/pages/evaluators/results/EvaluatorResultDetail.tsx
+++ b/frontend/src/pages/evaluators/results/EvaluatorResultDetail.tsx
@@ -492,28 +492,23 @@ export default function EvaluatorResultDetailPage({
 
     const streamId = result.result_id || id
     let eventSource: EventSource | null = null
-    let cancelled = false
 
-    void (async () => {
-      try {
-        const url = await apiClient.getEvaluatorResultLiveEventsUrl(streamId)
-        if (cancelled) return
-        eventSource = new EventSource(url)
-        eventSource.onmessage = (event) => {
-          try {
-            const entry = JSON.parse(event.data) as LiveTranscriptTurn
-            setLiveTranscript((prev) => [...prev, entry])
-          } catch {
-            // ignore malformed events
-          }
+    try {
+      const url = apiClient.getEvaluatorResultLiveEventsUrl(streamId)
+      eventSource = new EventSource(url, { withCredentials: true })
+      eventSource.onmessage = (event) => {
+        try {
+          const entry = JSON.parse(event.data) as LiveTranscriptTurn
+          setLiveTranscript((prev) => [...prev, entry])
+        } catch {
+          // ignore malformed events
         }
-      } catch {
-        // polling via react-query still updates live_transcript from call_data
       }
-    })()
+    } catch {
+      // polling via react-query still updates live_transcript from call_data
+    }
 
     return () => {
-      cancelled = true
       eventSource?.close()
     }
   }, [id, result?.result_id, result?.status, result?.call_data?.is_live])

--- a/frontend/src/pages/evaluators/results/EvaluatorResultDetail.tsx
+++ b/frontend/src/pages/evaluators/results/EvaluatorResultDetail.tsx
@@ -492,21 +492,28 @@ export default function EvaluatorResultDetailPage({
 
     const streamId = result.result_id || id
     let eventSource: EventSource | null = null
-    try {
-      eventSource = new EventSource(apiClient.getEvaluatorResultLiveEventsUrl(streamId))
-      eventSource.onmessage = (event) => {
-        try {
-          const entry = JSON.parse(event.data) as LiveTranscriptTurn
-          setLiveTranscript((prev) => [...prev, entry])
-        } catch {
-          // ignore malformed events
+    let cancelled = false
+
+    void (async () => {
+      try {
+        const url = await apiClient.getEvaluatorResultLiveEventsUrl(streamId)
+        if (cancelled) return
+        eventSource = new EventSource(url)
+        eventSource.onmessage = (event) => {
+          try {
+            const entry = JSON.parse(event.data) as LiveTranscriptTurn
+            setLiveTranscript((prev) => [...prev, entry])
+          } catch {
+            // ignore malformed events
+          }
         }
+      } catch {
+        // polling via react-query still updates live_transcript from call_data
       }
-    } catch {
-      // polling via react-query still updates live_transcript from call_data
-    }
+    })()
 
     return () => {
+      cancelled = true
       eventSource?.close()
     }
   }, [id, result?.result_id, result?.status, result?.call_data?.is_live])

--- a/frontend/src/pages/iam/IAM.tsx
+++ b/frontend/src/pages/iam/IAM.tsx
@@ -5,6 +5,7 @@ import { useSearchParams } from 'react-router-dom'
 import { Role, Invitation, OrganizationMember, InvitationCreate } from '../../types/api'
 import { Users, Mail, UserPlus, Shield, ShieldCheck, ShieldAlert, X, Trash2, KeyRound, Eye, EyeOff, Building2, Copy, Check } from 'lucide-react'
 import Button from '../../components/Button'
+import ConfirmModal from '../../components/ConfirmModal'
 import { useToast } from '../../hooks/useToast'
 import { getApiErrorMessage } from '../../lib/apiErrors'
 import { useIsAdmin } from '../../hooks/useRole'
@@ -146,6 +147,12 @@ export default function IAM() {
     },
   })
 
+  const closeRemoveModal = () => {
+    if (removeUserMutation.isPending) return
+    setShowRemoveModal(false)
+    setMemberToRemove(null)
+  }
+
   const handleRemoveClick = (member: OrganizationMember) => {
     setMemberToRemove(member)
     setShowRemoveModal(true)
@@ -155,6 +162,12 @@ export default function IAM() {
     if (memberToRemove) {
       removeUserMutation.mutate(memberToRemove.user_id)
     }
+  }
+
+  const closeCancelModal = () => {
+    if (cancelInvitationMutation.isPending) return
+    setShowCancelModal(false)
+    setInvitationToCancel(null)
   }
 
   const cancelInvitationMutation = useMutation({
@@ -716,64 +729,48 @@ export default function IAM() {
         </div>
       )}
 
-      {/* Remove User Confirmation Modal */}
-      {showRemoveModal && memberToRemove && (
-        <div className="fixed inset-0 bg-gray-500 bg-opacity-75 flex items-center justify-center z-50" onClick={() => setShowRemoveModal(false)}>
-          <div className="bg-white rounded-lg shadow-xl max-w-md w-full mx-4" onClick={(e) => e.stopPropagation()}>
-            <div className="px-6 py-4 border-b border-gray-200 flex justify-between items-center">
-              <h3 className="text-lg font-semibold text-gray-900">Remove User</h3>
-              <button
-                onClick={() => {
-                  setShowRemoveModal(false)
-                  setMemberToRemove(null)
-                }}
-                className="text-gray-400 hover:text-gray-600"
-              >
-                <X className="h-5 w-5" />
-              </button>
+      <ConfirmModal
+        isOpen={showRemoveModal && !!memberToRemove}
+        title="Remove member from organization?"
+        confirmLabel="Remove member"
+        cancelLabel="Keep member"
+        variant="danger"
+        isLoading={removeUserMutation.isPending}
+        onCancel={closeRemoveModal}
+        onConfirm={handleRemoveConfirm}
+      >
+        {memberToRemove && (
+          <>
+            <p className="text-gray-700">
+              You are about to remove{' '}
+              <span className="font-semibold text-gray-900">
+                {memberToRemove.user.name || memberToRemove.user.email}
+              </span>
+              {memberToRemove.user.name ? (
+                <span className="text-gray-500"> ({memberToRemove.user.email})</span>
+              ) : null}{' '}
+              from this organization. They currently have the{' '}
+              <span className="font-medium capitalize text-gray-800">{memberToRemove.role}</span>{' '}
+              role.
+            </p>
+            <div className="rounded-xl border border-red-100 bg-red-50 px-4 py-3 text-red-900">
+              <p className="text-xs font-semibold uppercase tracking-wide text-red-800 mb-2">
+                This will immediately
+              </p>
+              <ul className="list-disc pl-5 space-y-1.5 text-sm text-red-900/90">
+                <li>Remove them from every workspace in this organization</li>
+                <li>Revoke their access to all organization data and settings</li>
+                <li>Delete their organization-specific password for this org</li>
+                <li>Sign them out of any active sessions for this organization</li>
+              </ul>
             </div>
-            <div className="p-6">
-              <div className="flex items-start gap-4 mb-6">
-                <div className="flex-shrink-0">
-                  <div className="w-12 h-12 rounded-full bg-red-100 flex items-center justify-center">
-                    <Trash2 className="h-6 w-6 text-red-600" />
-                  </div>
-                </div>
-                <div className="flex-1">
-                  <p className="text-sm text-gray-700 mb-2">
-                    Are you sure you want to remove <span className="font-semibold text-gray-900">{memberToRemove.user.name || memberToRemove.user.email}</span> from the organization?
-                  </p>
-                  <p className="text-xs text-gray-500">
-                    This action cannot be undone. The user will lose access to all organization resources.
-                  </p>
-                </div>
-              </div>
-              <div className="flex gap-3">
-                <Button
-                  variant="outline"
-                  onClick={() => {
-                    setShowRemoveModal(false)
-                    setMemberToRemove(null)
-                  }}
-                  disabled={removeUserMutation.isPending}
-                  className="flex-1"
-                >
-                  Cancel
-                </Button>
-                <Button
-                  variant="danger"
-                  onClick={handleRemoveConfirm}
-                  isLoading={removeUserMutation.isPending}
-                  leftIcon={!removeUserMutation.isPending ? <Trash2 className="h-4 w-4" /> : undefined}
-                  className="flex-1"
-                >
-                  Remove User
-                </Button>
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
+            <p className="text-xs text-gray-500">
+              You can invite them back later, but they may need a new password or admin reset
+              before they can sign in to this organization again.
+            </p>
+          </>
+        )}
+      </ConfirmModal>
 
       {/* Admin Reset Password Modal */}
       {showResetPasswordModal && memberToResetPassword && (
@@ -918,64 +915,31 @@ export default function IAM() {
         </div>
       )}
 
-      {/* Cancel Invitation Confirmation Modal */}
-      {showCancelModal && invitationToCancel && (
-        <div className="fixed inset-0 bg-gray-500 bg-opacity-75 flex items-center justify-center z-50" onClick={() => setShowCancelModal(false)}>
-          <div className="bg-white rounded-lg shadow-xl max-w-md w-full mx-4" onClick={(e) => e.stopPropagation()}>
-            <div className="px-6 py-4 border-b border-gray-200 flex justify-between items-center">
-              <h3 className="text-lg font-semibold text-gray-900">Cancel Invitation</h3>
-              <button
-                onClick={() => {
-                  setShowCancelModal(false)
-                  setInvitationToCancel(null)
-                }}
-                className="text-gray-400 hover:text-gray-600"
-              >
-                <X className="h-5 w-5" />
-              </button>
-            </div>
-            <div className="p-6">
-              <div className="flex items-start gap-4 mb-6">
-                <div className="flex-shrink-0">
-                  <div className="w-12 h-12 rounded-full bg-yellow-100 flex items-center justify-center">
-                    <X className="h-6 w-6 text-yellow-600" />
-                  </div>
-                </div>
-                <div className="flex-1">
-                  <p className="text-sm text-gray-700 mb-2">
-                    Are you sure you want to cancel the invitation for <span className="font-semibold text-gray-900">{invitationToCancel.email}</span>?
-                  </p>
-                  <p className="text-xs text-gray-500">
-                    This action cannot be undone. The invitation will be cancelled and the user will not be able to accept it.
-                  </p>
-                </div>
-              </div>
-              <div className="flex gap-3">
-                <Button
-                  variant="outline"
-                  onClick={() => {
-                    setShowCancelModal(false)
-                    setInvitationToCancel(null)
-                  }}
-                  disabled={cancelInvitationMutation.isPending}
-                  className="flex-1"
-                >
-                  Keep Invitation
-                </Button>
-                <Button
-                  variant="danger"
-                  onClick={handleCancelConfirm}
-                  isLoading={cancelInvitationMutation.isPending}
-                  leftIcon={!cancelInvitationMutation.isPending ? <X className="h-4 w-4" /> : undefined}
-                  className="flex-1"
-                >
-                  Cancel Invitation
-                </Button>
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
+      <ConfirmModal
+        isOpen={showCancelModal && !!invitationToCancel}
+        title="Cancel invitation?"
+        confirmLabel="Cancel invitation"
+        cancelLabel="Keep invitation"
+        variant="warning"
+        isLoading={cancelInvitationMutation.isPending}
+        onCancel={closeCancelModal}
+        onConfirm={handleCancelConfirm}
+      >
+        {invitationToCancel && (
+          <>
+            <p className="text-gray-700">
+              The pending invitation for{' '}
+              <span className="font-semibold text-gray-900">{invitationToCancel.email}</span> will
+              be withdrawn.
+            </p>
+            <ul className="list-disc pl-5 space-y-1.5">
+              <li>Any invite link you shared will stop working</li>
+              <li>They will not be added to this organization or its workspaces</li>
+              <li>You can send a new invitation later if needed</li>
+            </ul>
+          </>
+        )}
+      </ConfirmModal>
     </div>
   )
 }

--- a/frontend/src/pages/metrics/Metrics.tsx
+++ b/frontend/src/pages/metrics/Metrics.tsx
@@ -62,17 +62,7 @@ function ConversationEvaluationSection() {
     queryFn: async () => {
       if (!selectedAgent?.id) return []
       try {
-        const API_BASE_URL = (import.meta as any).env?.VITE_API_URL || 'http://localhost:8000'
-        const apiKey = localStorage.getItem('apiKey') || ''
-        const params = new URLSearchParams({ agent_id: selectedAgent.id })
-        const response = await fetch(`${API_BASE_URL}/api/v1/conversation-evaluations?${params}`, {
-          headers: {
-            'X-API-Key': apiKey,
-            'Content-Type': 'application/json',
-          },
-        })
-        if (!response.ok) return []
-        return response.json()
+        return await apiClient.listConversationEvaluations(selectedAgent.id)
       } catch {
         return []
       }
@@ -83,21 +73,7 @@ function ConversationEvaluationSection() {
   // Create evaluation mutation
   const createEvaluationMutation = useMutation({
     mutationFn: async (data: { transcription_id: string; agent_id: string }) => {
-      const API_BASE_URL = (import.meta as any).env?.VITE_API_URL || 'http://localhost:8000'
-      const apiKey = localStorage.getItem('apiKey') || ''
-      const response = await fetch(`${API_BASE_URL}/api/v1/conversation-evaluations`, {
-        method: 'POST',
-        headers: {
-          'X-API-Key': apiKey,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(data),
-      })
-      if (!response.ok) {
-        const error = await response.json()
-        throw new Error(error.detail || 'Failed to create evaluation')
-      }
-      return response.json()
+      return apiClient.createConversationEvaluation(data)
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['conversation-evaluations'] })
@@ -108,20 +84,7 @@ function ConversationEvaluationSection() {
   // Delete evaluation mutation
   const deleteEvaluationMutation = useMutation({
     mutationFn: async (evaluationId: string) => {
-      const API_BASE_URL = (import.meta as any).env?.VITE_API_URL || 'http://localhost:8000'
-      const apiKey = localStorage.getItem('apiKey') || ''
-      const response = await fetch(`${API_BASE_URL}/api/v1/conversation-evaluations/${evaluationId}`, {
-        method: 'DELETE',
-        headers: {
-          'X-API-Key': apiKey,
-          'Content-Type': 'application/json',
-        },
-      })
-      if (!response.ok) {
-        const error = await response.json()
-        throw new Error(error.detail || 'Failed to delete evaluation')
-      }
-      return response.json()
+      await apiClient.deleteConversationEvaluation(evaluationId)
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['conversation-evaluations'] })
@@ -139,18 +102,8 @@ function ConversationEvaluationSection() {
     
     // Delete existing evaluation first, then create a new one
     try {
-      const API_BASE_URL = (import.meta as any).env?.VITE_API_URL || 'http://localhost:8000'
-      const apiKey = localStorage.getItem('apiKey') || ''
-      
-      // Delete existing evaluation
-      await fetch(`${API_BASE_URL}/api/v1/conversation-evaluations/${evaluationId}`, {
-        method: 'DELETE',
-        headers: {
-          'X-API-Key': apiKey,
-          'Content-Type': 'application/json',
-        },
-      })
-      
+      await apiClient.deleteConversationEvaluation(evaluationId)
+
       // Create new evaluation
       setSelectedTranscriptionId(transcriptionId)
       createEvaluationMutation.mutate({

--- a/frontend/src/pages/observability/ObservabilityCallDetail.tsx
+++ b/frontend/src/pages/observability/ObservabilityCallDetail.tsx
@@ -71,23 +71,29 @@ export default function ObservabilityCallDetail() {
     if (!isLive) return
 
     let eventSource: EventSource | null = null
-    try {
-      const url = apiClient.getObservabilityCallLiveEventsUrl(callShortId)
-      eventSource = new EventSource(url)
+    let cancelled = false
 
-      eventSource.onmessage = (event) => {
-        try {
-          const entry = JSON.parse(event.data)
-          setLiveTranscript((prev) => [...prev, entry])
-        } catch {
-          // ignore malformed events
+    void (async () => {
+      try {
+        const url = await apiClient.getObservabilityCallLiveEventsUrl(callShortId)
+        if (cancelled) return
+        eventSource = new EventSource(url)
+
+        eventSource.onmessage = (event) => {
+          try {
+            const entry = JSON.parse(event.data)
+            setLiveTranscript((prev) => [...prev, entry])
+          } catch {
+            // ignore malformed events
+          }
         }
+      } catch {
+        // Polling via react-query still updates live_transcript from call_data
       }
-    } catch {
-      // Polling via react-query still updates live_transcript from call_data
-    }
+    })()
 
     return () => {
+      cancelled = true
       eventSource?.close()
     }
   }, [callShortId, callRecording?.call_event, callRecording?.is_live])

--- a/frontend/src/pages/observability/ObservabilityCallDetail.tsx
+++ b/frontend/src/pages/observability/ObservabilityCallDetail.tsx
@@ -71,13 +71,10 @@ export default function ObservabilityCallDetail() {
     if (!isLive) return
 
     let eventSource: EventSource | null = null
-    let cancelled = false
 
-    void (async () => {
-      try {
-        const url = await apiClient.getObservabilityCallLiveEventsUrl(callShortId)
-        if (cancelled) return
-        eventSource = new EventSource(url)
+    try {
+        const url = apiClient.getObservabilityCallLiveEventsUrl(callShortId)
+        eventSource = new EventSource(url, { withCredentials: true })
 
         eventSource.onmessage = (event) => {
           try {
@@ -87,13 +84,11 @@ export default function ObservabilityCallDetail() {
             // ignore malformed events
           }
         }
-      } catch {
-        // Polling via react-query still updates live_transcript from call_data
-      }
-    })()
+    } catch {
+      // Polling via react-query still updates live_transcript from call_data
+    }
 
     return () => {
-      cancelled = true
       eventSource?.close()
     }
   }, [callShortId, callRecording?.call_event, callRecording?.is_live])

--- a/frontend/src/pages/playground/agent/AgentPlayground.tsx
+++ b/frontend/src/pages/playground/agent/AgentPlayground.tsx
@@ -49,6 +49,7 @@ export default function AgentPlayground() {
   const elevenLabsConversationRef = useRef<any>(null)
   const smallestClientRef = useRef<any>(null)
   const currentCallShortIdRef = useRef<string | null>(null)
+  const currentVapiCallIdRef = useRef<string | null>(null)
 
   const userInitiatedDisconnectRef = useRef(false)
 
@@ -388,7 +389,9 @@ export default function AgentPlayground() {
           setIsConnecting(false)
           showToast('Connected to agent', 'success')
 
-          // Update backend with Vapi Call ID
+          if (call?.id) {
+            currentVapiCallIdRef.current = call.id
+          }
           if (currentCallShortIdRef.current && call?.id) {
             try {
               await apiClient.updateCallRecording(currentCallShortIdRef.current, call.id)
@@ -416,20 +419,14 @@ export default function AgentPlayground() {
           }
           userInitiatedDisconnectRef.current = false
 
-          // Ensure we have provider ID before refreshing
           if (currentCallShortIdRef.current) {
-            if (call?.id) {
-              try {
-                await apiClient.updateCallRecording(currentCallShortIdRef.current, call.id)
-              } catch (e) {
-                console.error('Failed to update call recording on end', e)
-              }
-            }
-
-            apiClient.refreshCallRecording(currentCallShortIdRef.current)
+            const providerCallId = call?.id ?? currentVapiCallIdRef.current
+            apiClient
+              .finalizePlaygroundCallRecording(currentCallShortIdRef.current, providerCallId)
               .then(() => refetchCallRecordings())
-              .catch(err => console.error('Failed to refresh metrics', err))
+              .catch((err) => console.error('Failed to refresh metrics', err))
           }
+          currentVapiCallIdRef.current = null
         })
 
         client.on('error', (error: any) => {
@@ -445,7 +442,9 @@ export default function AgentPlayground() {
         const vapiCall = await client.start(fullAgent.voice_ai_agent_id)
         console.log('Vapi start returned:', vapiCall)
 
-        // Try to get ID from return value immediately
+        if (vapiCall?.id) {
+          currentVapiCallIdRef.current = vapiCall.id
+        }
         if (currentCallShortIdRef.current && vapiCall?.id) {
           try {
             await apiClient.updateCallRecording(currentCallShortIdRef.current, vapiCall.id)

--- a/frontend/src/pages/profile/Profile.tsx
+++ b/frontend/src/pages/profile/Profile.tsx
@@ -7,6 +7,8 @@ import Button from '../../components/Button'
 import { useAuthStore } from '../../store/authStore'
 import { redirectToLoginWithMessage } from '../../lib/authSession'
 import { PASSWORD_POLICY_HINT, validatePasswordPolicy } from '../../lib/passwordPolicy'
+import { useOrgSwitch } from '../../hooks/useOrgSwitch'
+import OrgReauthModal from '../../components/OrgReauthModal'
 
 export default function Profile() {
   const queryClient = useQueryClient()
@@ -130,15 +132,22 @@ export default function Profile() {
   // After a successful accept we remember what org the user just joined so
   // we can offer a one-click "Switch to <Org>" button. They can also switch
   // from the Organizations section below.
-  const { apiKey, user, switchOrg } = useAuthStore()
-  const [switchingOrgId, setSwitchingOrgId] = useState<string | null>(null)
-  const [orgSwitchError, setOrgSwitchError] = useState('')
+  const { apiKey, user } = useAuthStore()
+  const {
+    switchingTo,
+    error: orgSwitchError,
+    reauthTarget,
+    reauthError,
+    reauthLoading,
+    switchToOrg,
+    closeReauth,
+    submitReauth,
+    user: authUser,
+  } = useOrgSwitch()
   const [justJoined, setJustJoined] = useState<
     | { organizationId: string; organizationName: string; role: string }
     | null
   >(null)
-  const [isSwitchingToJoined, setIsSwitchingToJoined] = useState(false)
-  const [switchError, setSwitchError] = useState('')
 
   const acceptInvitationMutation = useMutation({
     mutationFn: (invitation: Invitation) => apiClient.acceptInvitation(invitation.id),
@@ -153,32 +162,26 @@ export default function Profile() {
     },
   })
 
-  const handleSwitchOrganization = async (orgId: string) => {
+  const handleSwitchOrganization = async (orgId: string, orgName: string) => {
     if (orgId === user?.organization_id) return
-    setOrgSwitchError('')
-    setSwitchingOrgId(orgId)
-    try {
-      await switchOrg(orgId)
-      await queryClient.invalidateQueries()
-    } catch (err: any) {
-      setOrgSwitchError(err?.response?.data?.detail || 'Could not switch organization')
-    } finally {
-      setSwitchingOrgId(null)
+    const switched = await switchToOrg(orgId, orgName)
+    if (switched && justJoined?.organizationId === orgId) {
+      setJustJoined(null)
     }
   }
 
   const handleJumpToJoinedOrg = async () => {
     if (!justJoined) return
-    setSwitchError('')
-    setIsSwitchingToJoined(true)
-    try {
-      await switchOrg(justJoined.organizationId)
-      await queryClient.invalidateQueries()
+    const switched = await switchToOrg(justJoined.organizationId, justJoined.organizationName)
+    if (switched) {
       setJustJoined(null)
-    } catch (err: any) {
-      setSwitchError(err?.response?.data?.detail || 'Could not switch organization')
-    } finally {
-      setIsSwitchingToJoined(false)
+    }
+  }
+
+  const handleReauth = async (password: string) => {
+    const ok = await submitReauth(password)
+    if (ok && justJoined && reauthTarget?.id === justJoined.organizationId) {
+      setJustJoined(null)
     }
   }
 
@@ -239,6 +242,7 @@ export default function Profile() {
   }
 
   return (
+    <>
     <div className="space-y-6">
       <div>
         <h1 className="text-3xl font-bold text-gray-900">Profile</h1>
@@ -514,7 +518,7 @@ export default function Profile() {
               )}
               {profile.organizations.map((org) => {
                 const isCurrent = org.id === user?.organization_id
-                const isSwitching = switchingOrgId === org.id
+                const isSwitching = switchingTo === org.id
                 const canSwitch = !apiKey && !!user && profile.organizations.length > 1
 
                 return (
@@ -543,8 +547,8 @@ export default function Profile() {
                         <Button
                           size="sm"
                           variant="outline"
-                          onClick={() => handleSwitchOrganization(org.id)}
-                          disabled={!!switchingOrgId}
+                          onClick={() => handleSwitchOrganization(org.id, org.name)}
+                          disabled={!!switchingTo}
                           leftIcon={
                             isSwitching ? (
                               <Loader2 className="h-4 w-4 animate-spin" />
@@ -579,33 +583,32 @@ export default function Profile() {
             <div className="text-xs text-green-800 mt-0.5">
               Your current session is still in your previous organization. Switch now to start working there.
             </div>
-            {switchError && (
-              <div className="text-xs text-red-700 mt-2">{switchError}</div>
+            {orgSwitchError && !reauthTarget && (
+              <div className="text-xs text-red-700 mt-2">{orgSwitchError}</div>
             )}
           </div>
           <div className="flex items-center gap-2 flex-shrink-0">
             <Button
               size="sm"
               onClick={handleJumpToJoinedOrg}
-              disabled={isSwitchingToJoined}
+              disabled={switchingTo === justJoined.organizationId}
               leftIcon={
-                isSwitchingToJoined ? (
+                switchingTo === justJoined.organizationId ? (
                   <Loader2 className="h-4 w-4 animate-spin" />
                 ) : (
                   <ArrowRightLeft className="h-4 w-4" />
                 )
               }
             >
-              {isSwitchingToJoined ? 'Switching…' : `Switch to ${justJoined.organizationName}`}
+              {switchingTo === justJoined.organizationId
+                ? 'Switching…'
+                : `Switch to ${justJoined.organizationName}`}
             </Button>
             <Button
               variant="ghost"
               size="sm"
-              onClick={() => {
-                setJustJoined(null)
-                setSwitchError('')
-              }}
-              disabled={isSwitchingToJoined}
+              onClick={() => setJustJoined(null)}
+              disabled={!!switchingTo}
             >
               Dismiss
             </Button>
@@ -682,6 +685,17 @@ export default function Profile() {
         </div>
       </div>
     </div>
+
+    <OrgReauthModal
+      open={!!reauthTarget}
+      organizationName={reauthTarget?.name ?? ''}
+      email={authUser?.email}
+      isLoading={reauthLoading}
+      error={reauthError}
+      onClose={closeReauth}
+      onSubmit={handleReauth}
+    />
+    </>
   )
 }
 

--- a/frontend/src/pages/profile/Profile.tsx
+++ b/frontend/src/pages/profile/Profile.tsx
@@ -13,7 +13,6 @@ export default function Profile() {
   const [name, setName] = useState('')
   const [firstName, setFirstName] = useState('')
   const [lastName, setLastName] = useState('')
-  const [email, setEmail] = useState('')
 
   const { data: profile, isLoading: profileLoading } = useQuery<ProfileType>({
     queryKey: ['profile'],
@@ -111,7 +110,6 @@ export default function Profile() {
       setName(profile.name || '')
       setFirstName(profile.first_name || '')
       setLastName(profile.last_name || '')
-      setEmail(profile.email)
     }
   }, [profile])
 
@@ -131,7 +129,7 @@ export default function Profile() {
   // After a successful accept we remember what org the user just joined so
   // we can offer a one-click "Switch to <Org>" button. They can also switch
   // from the Organizations section below.
-  const { accessToken, user, switchOrg } = useAuthStore()
+  const { apiKey, user, switchOrg } = useAuthStore()
   const [switchingOrgId, setSwitchingOrgId] = useState<string | null>(null)
   const [orgSwitchError, setOrgSwitchError] = useState('')
   const [justJoined, setJustJoined] = useState<
@@ -192,11 +190,10 @@ export default function Profile() {
 
   const handleSave = (e: React.FormEvent) => {
     e.preventDefault()
-    updateMutation.mutate({ 
-      name: name || undefined, 
+    updateMutation.mutate({
+      name: name || undefined,
       first_name: firstName || undefined,
       last_name: lastName || undefined,
-      email 
     })
   }
 
@@ -206,7 +203,6 @@ export default function Profile() {
       setName(profile.name || '')
       setFirstName(profile.first_name || '')
       setLastName(profile.last_name || '')
-      setEmail(profile.email)
     }
   }
 
@@ -307,20 +303,6 @@ export default function Profile() {
                   onChange={(e) => setName(e.target.value)}
                   className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
                   placeholder="Your full name"
-                />
-              </div>
-              <div>
-                <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-1">
-                  Email
-                </label>
-                <input
-                  id="email"
-                  type="email"
-                  required
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent"
-                  placeholder="your@email.com"
                 />
               </div>
               <div className="flex gap-3 pt-4">
@@ -515,7 +497,7 @@ export default function Profile() {
             <Building2 className="h-5 w-5" />
             Organizations
           </h2>
-          {accessToken && (profile?.organizations?.length ?? 0) > 1 && (
+          {!apiKey && user && (profile?.organizations?.length ?? 0) > 1 && (
             <p className="mt-1 text-sm text-gray-500">
               Switch between organizations you belong to.
             </p>
@@ -532,7 +514,7 @@ export default function Profile() {
               {profile.organizations.map((org) => {
                 const isCurrent = org.id === user?.organization_id
                 const isSwitching = switchingOrgId === org.id
-                const canSwitch = !!accessToken && profile.organizations.length > 1
+                const canSwitch = !apiKey && !!user && profile.organizations.length > 1
 
                 return (
                   <div
@@ -585,7 +567,7 @@ export default function Profile() {
       </div>
 
       {/* Post-accept switch prompt */}
-      {justJoined && accessToken && (
+      {justJoined && user && !apiKey && (
         <div className="bg-green-50 border border-green-200 rounded-lg p-4 flex items-start gap-3">
           <CheckCircle className="h-5 w-5 text-green-600 flex-shrink-0 mt-0.5" />
           <div className="flex-1 min-w-0">

--- a/frontend/src/pages/profile/Profile.tsx
+++ b/frontend/src/pages/profile/Profile.tsx
@@ -23,7 +23,7 @@ export default function Profile() {
   // Separately call /auth/me to find out whether this user already has a
   // password set and whether their email is still the synthetic placeholder
   // we create for raw API-key users.
-  const { data: authMe, refetch: refetchMe } = useQuery({
+  const { data: authMe } = useQuery({
     queryKey: ['auth', 'me'],
     queryFn: () => apiClient.getMe(),
   })

--- a/frontend/src/pages/profile/Profile.tsx
+++ b/frontend/src/pages/profile/Profile.tsx
@@ -145,19 +145,25 @@ export default function Profile() {
     user: authUser,
   } = useOrgSwitch()
   const [justJoined, setJustJoined] = useState<
-    | { organizationId: string; organizationName: string; role: string }
+    | {
+        organizationId: string
+        organizationName: string
+        role: string
+        joinNotice?: string | null
+      }
     | null
   >(null)
 
   const acceptInvitationMutation = useMutation({
     mutationFn: (invitation: Invitation) => apiClient.acceptInvitation(invitation.id),
-    onSuccess: (_data, invitation) => {
+    onSuccess: (data, invitation) => {
       queryClient.invalidateQueries({ queryKey: ['profile'] })
       queryClient.invalidateQueries({ queryKey: ['iam'] })
       setJustJoined({
         organizationId: invitation.organization_id,
         organizationName: invitation.organization_name || 'the organization',
         role: invitation.role,
+        joinNotice: data.join_notice,
       })
     },
   })
@@ -580,6 +586,9 @@ export default function Profile() {
               You&apos;ve joined <span className="font-semibold">{justJoined.organizationName}</span>{' '}
               as {justJoined.role}.
             </div>
+            {justJoined.joinNotice && (
+              <div className="text-xs text-green-800 mt-0.5 leading-relaxed">{justJoined.joinNotice}</div>
+            )}
             <div className="text-xs text-green-800 mt-0.5">
               Your current session is still in your previous organization. Switch now to start working there.
             </div>

--- a/frontend/src/pages/profile/Profile.tsx
+++ b/frontend/src/pages/profile/Profile.tsx
@@ -5,6 +5,7 @@ import { Profile as ProfileType, Invitation, UserUpdate, InvitationStatus } from
 import { User, Mail, Building2, CheckCircle, XCircle, KeyRound, AlertTriangle, ArrowRightLeft, Loader2 } from 'lucide-react'
 import Button from '../../components/Button'
 import { useAuthStore } from '../../store/authStore'
+import { redirectToLoginWithMessage } from '../../lib/authSession'
 import { PASSWORD_POLICY_HINT, validatePasswordPolicy } from '../../lib/passwordPolicy'
 
 export default function Profile() {
@@ -52,16 +53,16 @@ export default function Profile() {
       apiClient.setPassword(data),
     onSuccess: (data) => {
       const hadPasswordBefore = !!authMe?.has_password
-      setPwError('')
-      setPwSuccess(
-        hadPasswordBefore
-          ? 'Password updated successfully.'
-          : `Password set. You can now sign in with ${data.email} and your new password.`
-      )
       resetPasswordForm()
       setIsEditingPassword(false)
-      refetchMe()
-      queryClient.invalidateQueries({ queryKey: ['profile'] })
+      queryClient.clear()
+      const { logout } = useAuthStore.getState()
+      logout()
+      redirectToLoginWithMessage(
+        hadPasswordBefore
+          ? 'Password updated. Sign in again with your new password.'
+          : `Password set for ${data.email}. Sign in with your new password.`,
+      )
     },
     onError: (err: any) => {
       setPwSuccess('')

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -3,17 +3,6 @@ import { apiClient } from '../lib/api'
 import { clearAuthSession } from '../lib/authSession'
 import { useWorkspaceStore } from './workspaceStore'
 
-/**
- * Auth store for the EfficientAI frontend.
- *
- * Supports two credential types in parallel:
- *   - Bearer access token (local password login or SSO). Preferred for humans.
- *   - API key (machine / legacy access). Kept for backward compatibility.
- *
- * Having either one populated makes the SPA treat the user as authenticated.
- * The API client prefers the Bearer token when both are set.
- */
-
 type AuthUser = {
   id: string
   email: string
@@ -24,92 +13,88 @@ type AuthUser = {
   role?: string | null
 }
 
+type SessionTokens = {
+  access?: string
+  refresh?: string
+}
+
 interface AuthState {
   apiKey: string | null
   accessToken: string | null
   refreshToken: string | null
+  cookieSession: boolean
   user: AuthUser | null
   isLoading: boolean
+  sessionReady: boolean
 
   setApiKey: (key: string) => void
-  setSession: (token: string, user: AuthUser, refreshToken?: string | null) => void
+  setSession: (user: AuthUser, tokens?: SessionTokens) => void
   switchOrg: (organizationId: string) => Promise<AuthUser>
   logout: () => void
   validate: () => Promise<boolean>
+  bootstrapSession: () => Promise<void>
 }
 
 const STORAGE_API_KEY = 'apiKey'
-const STORAGE_ACCESS_TOKEN = 'accessToken'
-const STORAGE_REFRESH_TOKEN = 'refreshToken'
-const STORAGE_USER = 'authUser'
 
 function readStoredUser(): AuthUser | null {
   try {
-    const raw = localStorage.getItem(STORAGE_USER)
+    const raw = localStorage.getItem('authUser')
     return raw ? (JSON.parse(raw) as AuthUser) : null
   } catch {
     return null
   }
 }
 
+localStorage.removeItem('accessToken')
+localStorage.removeItem('refreshToken')
+
 export const useAuthStore = create<AuthState>((set, get) => {
   const storedKey = localStorage.getItem(STORAGE_API_KEY)
-  const storedToken = localStorage.getItem(STORAGE_ACCESS_TOKEN)
-  const storedRefreshToken = localStorage.getItem(STORAGE_REFRESH_TOKEN)
-
   if (storedKey) {
     apiClient.setApiKey(storedKey)
-  }
-  if (storedToken) {
-    apiClient.setAccessToken(storedToken)
-  }
-  if (storedRefreshToken) {
-    apiClient.setRefreshToken(storedRefreshToken)
   }
 
   return {
     apiKey: storedKey,
-    accessToken: storedToken,
-    refreshToken: storedRefreshToken,
+    accessToken: null,
+    refreshToken: null,
+    cookieSession: false,
     user: readStoredUser(),
     isLoading: false,
+    sessionReady: false,
 
     setApiKey: (key: string) => {
       apiClient.setApiKey(key)
       localStorage.setItem(STORAGE_API_KEY, key)
-      set({ apiKey: key })
+      set({ apiKey: key, cookieSession: false })
     },
 
-    setSession: (token: string, user: AuthUser, refreshToken?: string | null) => {
-      apiClient.setAccessToken(token)
-      localStorage.setItem(STORAGE_ACCESS_TOKEN, token)
-      localStorage.setItem(STORAGE_USER, JSON.stringify(user))
-      if (refreshToken) {
-        apiClient.setRefreshToken(refreshToken)
-        localStorage.setItem(STORAGE_REFRESH_TOKEN, refreshToken)
+    setSession: (user: AuthUser, tokens?: SessionTokens) => {
+      apiClient.clearInMemoryTokens()
+      if (tokens?.access) {
+        apiClient.setAccessToken(tokens.access)
       }
+      if (tokens?.refresh) {
+        apiClient.setRefreshToken(tokens.refresh)
+      }
+      localStorage.setItem('authUser', JSON.stringify(user))
       set({
-        accessToken: token,
-        refreshToken: refreshToken ?? get().refreshToken,
+        accessToken: tokens?.access ?? null,
+        refreshToken: tokens?.refresh ?? null,
+        cookieSession: !tokens?.access && apiClient.isCookieSessionEnabled(),
         user,
+        sessionReady: true,
       })
     },
 
     switchOrg: async (organizationId: string) => {
       const { access_token, refresh_token, user } = await apiClient.switchOrganization(organizationId)
-      apiClient.setAccessToken(access_token)
-      localStorage.setItem(STORAGE_ACCESS_TOKEN, access_token)
-      localStorage.setItem(STORAGE_USER, JSON.stringify(user))
-      if (refresh_token) {
-        apiClient.setRefreshToken(refresh_token)
-        localStorage.setItem(STORAGE_REFRESH_TOKEN, refresh_token)
-      }
-      useWorkspaceStore.getState().clearActiveWorkspaceId()
-      set({
-        accessToken: access_token,
-        refreshToken: refresh_token ?? get().refreshToken,
-        user,
+      get().setSession(user, {
+        access: access_token || undefined,
+        refresh: refresh_token,
       })
+      useWorkspaceStore.getState().clearActiveWorkspaceId()
       return user
     },
 
@@ -120,8 +105,16 @@ export const useAuthStore = create<AuthState>((set, get) => {
         apiKey: get().apiKey,
       }
       clearAuthSession()
+      apiClient.clearInMemoryTokens()
       useWorkspaceStore.getState().clearActiveWorkspaceId()
-      set({ apiKey: null, accessToken: null, refreshToken: null, user: null })
+      set({
+        apiKey: null,
+        accessToken: null,
+        refreshToken: null,
+        cookieSession: false,
+        user: null,
+        sessionReady: true,
+      })
       apiClient.revokeUserSessionBestEffort(credentials)
     },
 
@@ -134,6 +127,31 @@ export const useAuthStore = create<AuthState>((set, get) => {
         return false
       } finally {
         set({ isLoading: false })
+      }
+    },
+
+    bootstrapSession: async () => {
+      if (get().sessionReady) {
+        return
+      }
+      if (get().apiKey) {
+        set({ sessionReady: true, cookieSession: false })
+        return
+      }
+      try {
+        const config = await apiClient.getAuthConfig()
+        apiClient.setCookieSessionEnabled(Boolean(config.cookie_session_enabled))
+        const user = await apiClient.getMe()
+        localStorage.setItem('authUser', JSON.stringify(user))
+        set({
+          user,
+          cookieSession: Boolean(config.cookie_session_enabled),
+          accessToken: null,
+          refreshToken: null,
+          sessionReady: true,
+        })
+      } catch {
+        set({ sessionReady: true, user: null, cookieSession: false })
       }
     },
   }

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand'
-import { apiClient } from '../lib/api'
+import { apiClient, isLoginOrgSelectionResponse } from '../lib/api'
 import { clearAuthSession } from '../lib/authSession'
 import { useWorkspaceStore } from './workspaceStore'
 
@@ -30,6 +30,7 @@ interface AuthState {
   setApiKey: (key: string) => void
   setSession: (user: AuthUser, tokens?: SessionTokens) => void
   switchOrg: (organizationId: string) => Promise<AuthUser>
+  reauthForOrg: (organizationId: string, password: string) => Promise<AuthUser>
   logout: () => void
   validate: () => Promise<boolean>
   bootstrapSession: () => Promise<void>
@@ -96,6 +97,27 @@ export const useAuthStore = create<AuthState>((set, get) => {
       })
       useWorkspaceStore.getState().clearActiveWorkspaceId()
       return user
+    },
+
+    reauthForOrg: async (organizationId: string, password: string) => {
+      const currentUser = get().user
+      if (!currentUser?.email) {
+        throw new Error('No signed-in user')
+      }
+      const res = await apiClient.loginWithPassword(
+        currentUser.email,
+        password,
+        organizationId,
+      )
+      if (isLoginOrgSelectionResponse(res)) {
+        throw new Error('Password did not unlock the selected organization')
+      }
+      get().setSession(res.user, {
+        access: res.access_token || undefined,
+        refresh: res.refresh_token,
+      })
+      useWorkspaceStore.getState().clearActiveWorkspaceId()
+      return res.user
     },
 
     logout: () => {

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -103,6 +103,7 @@ export const useAuthStore = create<AuthState>((set, get) => {
         accessToken: get().accessToken,
         refreshToken: get().refreshToken,
         apiKey: get().apiKey,
+        cookieSession: get().cookieSession,
       }
       clearAuthSession()
       apiClient.clearInMemoryTokens()

--- a/frontend/src/store/platformAdminStore.ts
+++ b/frontend/src/store/platformAdminStore.ts
@@ -34,9 +34,13 @@ export const usePlatformAdminStore = create<PlatformAdminState>((set, get) => {
     accessToken: storedToken,
     admin: storedAdmin,
     setSession: (token, admin) => {
-      localStorage.setItem(STORAGE_TOKEN, token)
+      if (token) {
+        localStorage.setItem(STORAGE_TOKEN, token)
+      } else {
+        localStorage.removeItem(STORAGE_TOKEN)
+      }
       localStorage.setItem(STORAGE_ADMIN, JSON.stringify(admin))
-      set({ accessToken: token, admin })
+      set({ accessToken: token || null, admin })
     },
     logout: () => {
       const accessToken = get().accessToken
@@ -48,5 +52,6 @@ export const usePlatformAdminStore = create<PlatformAdminState>((set, get) => {
 })
 
 export function isPlatformAdminAuthenticated(): boolean {
-  return Boolean(localStorage.getItem(STORAGE_TOKEN))
+  const state = usePlatformAdminStore.getState()
+  return Boolean(state.accessToken || state.admin)
 }

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -223,6 +223,11 @@ export interface MessageResponse {
   message: string
 }
 
+export interface InvitationAcceptResponse {
+  message: string
+  join_notice?: string | null
+}
+
 // IAM & User Types
 export enum Role {
   READER = 'reader',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,6 +94,15 @@ def disable_db_sharding_for_tests(monkeypatch, request):
 
 
 @pytest.fixture(autouse=True)
+def disable_cookie_sessions_in_tests(monkeypatch):
+    """Keep legacy Bearer-token API tests stable; cookie auth has dedicated tests."""
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "AUTH_COOKIE_SESSION_ENABLED", False, raising=False)
+    yield
+
+
+@pytest.fixture(autouse=True)
 def ensure_workers_tasks_package():
     """Keep ``app.workers.tasks`` importable without eager Celery imports."""
     import importlib
@@ -880,6 +889,11 @@ def _build_session_api_app():
     )
 
     app = FastAPI()
+    from app.core.rbac_middleware import ReaderReadOnlyMiddleware
+    from app.core.csrf_middleware import CsrfMiddleware
+
+    app.add_middleware(CsrfMiddleware)
+    app.add_middleware(ReaderReadOnlyMiddleware)
     app.include_router(auth.router, prefix="/api/v1")
     app.include_router(evaluations.router, prefix="/api/v1")
     app.include_router(results.router, prefix="/api/v1")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -490,7 +490,11 @@ def _install_static_stubs():
         sys.modules["app.services.testing.test_agent_service"] = fake_test_agent_service_module
 
     if "app.services.voice_providers" not in sys.modules:
-        fake_voice_providers_module = types.ModuleType("app.services.voice_providers")
+        voice_providers_dir = str(
+            Path(__file__).resolve().parents[1] / "app" / "services" / "voice_providers"
+        )
+        fake_voice_providers_pkg = types.ModuleType("app.services.voice_providers")
+        fake_voice_providers_pkg.__path__ = [voice_providers_dir]
 
         class _FakeVoiceProvider:
             def __init__(self, *args, **kwargs):
@@ -502,9 +506,9 @@ def _install_static_stubs():
             def update_agent_prompt(self, **_kwargs):
                 return {"ok": True}
 
-        fake_voice_providers_module.get_voice_provider = lambda *_args, **_kwargs: _FakeVoiceProvider
-        fake_voice_providers_module.sync_provider_prompt = lambda *_args, **_kwargs: {"synced": False}
-        sys.modules["app.services.voice_providers"] = fake_voice_providers_module
+        fake_voice_providers_pkg.get_voice_provider = lambda *_args, **_kwargs: _FakeVoiceProvider
+        fake_voice_providers_pkg.sync_provider_prompt = lambda *_args, **_kwargs: {"synced": False}
+        sys.modules["app.services.voice_providers"] = fake_voice_providers_pkg
 
     if "app.services.voice_agent.bot_fast_api" not in sys.modules:
         voice_agent_dir = str(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,6 +103,20 @@ def disable_cookie_sessions_in_tests(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def disable_api_rate_limits_in_tests(monkeypatch, request):
+    """Avoid flaky 429s from shared Redis counters across the full test suite."""
+    fspath = str(getattr(request.node, "fspath", ""))
+    if "test_security_remediation.py" in fspath:
+        yield
+        return
+
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "API_RATE_LIMIT_ENFORCE", False, raising=False)
+    yield
+
+
+@pytest.fixture(autouse=True)
 def ensure_workers_tasks_package():
     """Keep ``app.workers.tasks`` importable without eager Celery imports."""
     import importlib

--- a/tests/test_api/test_auth_routes.py
+++ b/tests/test_api/test_auth_routes.py
@@ -932,6 +932,7 @@ def test_signup_with_invite_token_joins_invited_org(
 
     assert response.status_code == 200
     body = response.json()
+    assert body.get("join_notice") in (None, "")
     assert body["user"]["organization_id"] == str(org_id)
     assert body["user"]["role"] == RoleEnum.READER.value
 
@@ -1041,6 +1042,9 @@ def test_accept_invitation_by_token_issues_org_scoped_session(
     body = response.json()
     assert body["user"]["organization_id"] == str(invited_org.id)
     assert body["user"]["role"] == RoleEnum.WRITER.value
+    assert body.get("join_notice")
+    assert "Target Org" in body["join_notice"]
+    assert "password" in body["join_notice"].lower()
 
     workspace_membership = (
         db_session.query(WorkspaceMember)

--- a/tests/test_api/test_auth_routes.py
+++ b/tests/test_api/test_auth_routes.py
@@ -583,6 +583,48 @@ def test_rotating_password_requires_current_password(
     assert verify_password("Original1!", user.password_hash) is False
 
 
+def test_password_change_invalidates_existing_access_token(
+    db_session, org_id, seed_org, enable_local_password,
+):
+    from app.core.auth.local import LocalPasswordProvider
+    from app.core.auth.providers import AuthError, RawCredential, reset_provider_registry
+    from app.core.auth.session_epoch import bump_user_session_epoch
+    from app.core.auth.tokens import create_access_token
+
+    reset_provider_registry()
+    user = User(
+        id=uuid4(),
+        email="epoch@example.com",
+        password_hash=hash_password("Original1!"),
+        is_active=True,
+        session_epoch=0,
+    )
+    db_session.add(user)
+    db_session.add(
+        OrganizationMember(
+            organization_id=org_id,
+            user_id=user.id,
+            role=RoleEnum.ADMIN.value,
+        )
+    )
+    db_session.commit()
+
+    token, _, _ = create_access_token(
+        user_id=user.id,
+        organization_id=org_id,
+        email=user.email,
+        session_epoch=user.session_epoch,
+    )
+    provider = LocalPasswordProvider()
+    provider.authenticate(RawCredential(bearer_token=token), db_session)
+
+    bump_user_session_epoch(user)
+    db_session.commit()
+
+    with pytest.raises(AuthError, match="Session expired"):
+        provider.authenticate(RawCredential(bearer_token=token), db_session)
+
+
 # ---------------------------------------------------------------------------
 # POST /auth/switch-org - scoped token re-issuance
 # ---------------------------------------------------------------------------

--- a/tests/test_api/test_auth_routes.py
+++ b/tests/test_api/test_auth_routes.py
@@ -288,6 +288,8 @@ def test_signup_returns_404_when_local_password_disabled(client, monkeypatch):
 
 def _seed_user_with_org(db_session, email, password, *, role=RoleEnum.ADMIN.value):
     """Create a user + org + membership + return (user, org)."""
+    from app.core.auth.org_credentials import provision_membership_credential, set_org_password_hash
+
     org = Organization(id=uuid4(), name="Login Test Org")
     user = User(
         id=uuid4(),
@@ -301,6 +303,11 @@ def _seed_user_with_org(db_session, email, password, *, role=RoleEnum.ADMIN.valu
     db_session.add(
         OrganizationMember(organization_id=org.id, user_id=user.id, role=role)
     )
+    db_session.flush()
+    credential = provision_membership_credential(
+        db_session, user_id=user.id, organization_id=org.id
+    )
+    set_org_password_hash(credential, hash_password(password))
     db_session.commit()
     return user, org
 
@@ -371,10 +378,13 @@ def test_login_rejects_user_without_membership_with_403(
 
 
 def _seed_user_with_multiple_orgs(db_session, email, password):
+    from app.core.auth.org_credentials import provision_membership_credential, set_org_password_hash
+
+    password_hash = hash_password(password)
     user = User(
         id=uuid4(),
         email=email,
-        password_hash=hash_password(password),
+        password_hash=password_hash,
         is_active=True,
         auth_provider="local",
     )
@@ -388,6 +398,12 @@ def _seed_user_with_multiple_orgs(db_session, email, password):
             OrganizationMember(organization_id=org_b.id, user_id=user.id, role=RoleEnum.READER.value),
         ]
     )
+    db_session.flush()
+    for org in (org_a, org_b):
+        credential = provision_membership_credential(
+            db_session, user_id=user.id, organization_id=org.id
+        )
+        set_org_password_hash(credential, password_hash)
     db_session.commit()
     return user, org_a, org_b
 
@@ -505,8 +521,13 @@ def test_api_key_user_can_attach_password_and_real_email(
     assert body["email_is_placeholder"] is False
 
     db_session.refresh(user)
+    from app.core.auth.org_credentials import get_credential
+    from app.core.password import verify_password
+
     assert user.email == "alice@example.com"
-    assert user.password_hash is not None
+    credential = get_credential(db_session, user_id=user.id, organization_id=org_id)
+    assert credential is not None
+    assert verify_password("FreshPass1!", credential.password_hash)
 
 
 def test_set_password_rejects_email_change_for_non_placeholder_user(
@@ -577,10 +598,13 @@ def test_rotating_password_requires_current_password(
     assert correct.status_code == 200
 
     db_session.refresh(user)
+    from app.core.auth.org_credentials import get_credential
     from app.core.password import verify_password
 
-    assert verify_password("BrandNew1!", user.password_hash) is True
-    assert verify_password("Original1!", user.password_hash) is False
+    credential = get_credential(db_session, user_id=user.id, organization_id=org_id)
+    assert credential is not None
+    assert verify_password("BrandNew1!", credential.password_hash) is True
+    assert verify_password("Original1!", credential.password_hash) is False
 
 
 def test_password_change_invalidates_existing_access_token(
@@ -986,6 +1010,13 @@ def test_accept_invitation_by_token_issues_org_scoped_session(
             role=RoleEnum.ADMIN.value,
         )
     )
+    db_session.flush()
+    from app.core.auth.org_credentials import provision_membership_credential, set_org_password_hash
+
+    home_cred = provision_membership_credential(
+        db_session, user_id=existing_user.id, organization_id=home_org.id
+    )
+    set_org_password_hash(home_cred, existing_user.password_hash)
     provision_default_workspace(
         db_session,
         organization_id=invited_org.id,

--- a/tests/test_api/test_auth_routes.py
+++ b/tests/test_api/test_auth_routes.py
@@ -962,6 +962,7 @@ def test_refresh_preserves_authenticated_org_ids_with_expired_access_token(
         organization_id=org_a.id,
         email=user.email,
         authenticated_org_ids=[str(org_a.id), str(org_b.id)],
+        authenticated_org_epochs={str(org_a.id): 0, str(org_b.id): 0},
         expires_in_minutes=-1,
     )
 

--- a/tests/test_api/test_auth_routes.py
+++ b/tests/test_api/test_auth_routes.py
@@ -549,14 +549,14 @@ def test_rotating_password_requires_current_password(
     db_session.flush()
     _bind_api_key_to_user(db_session, api_key=api_key, org_id=org_id, user=user)
 
-    # Missing current_password -> 401.
+    # Missing current_password -> 400 (validation, not session expiry).
     missing_current = authenticated_client.post(
         "/api/v1/auth/password",
         json={"new_password": "BrandNew1!"},
     )
-    assert missing_current.status_code == 401
+    assert missing_current.status_code == 400
 
-    # Wrong current_password -> 401.
+    # Wrong current_password -> 400 (validation, not session expiry).
     wrong_current = authenticated_client.post(
         "/api/v1/auth/password",
         json={
@@ -564,7 +564,7 @@ def test_rotating_password_requires_current_password(
             "current_password": "not-the-real-one",
         },
     )
-    assert wrong_current.status_code == 401
+    assert wrong_current.status_code == 400
 
     # Correct current_password -> 200 and password actually changes.
     correct = authenticated_client.post(

--- a/tests/test_api/test_auth_routes.py
+++ b/tests/test_api/test_auth_routes.py
@@ -808,6 +808,7 @@ def test_refresh_rotates_tokens(client, db_session, enable_local_password):
     refreshed = client.post(
         "/api/v1/auth/refresh",
         json={"refresh_token": old_refresh},
+        headers={"Authorization": f"Bearer {login['access_token']}"},
     )
     assert refreshed.status_code == 200
     body = refreshed.json()
@@ -820,6 +821,35 @@ def test_refresh_rotates_tokens(client, db_session, enable_local_password):
         json={"refresh_token": old_refresh},
     )
     assert stale.status_code == 401
+
+
+def test_refresh_preserves_authenticated_org_ids(client, db_session, enable_local_password):
+    from app.core.auth.tokens import decode_access_token
+
+    user, org_a, org_b = _seed_user_with_multiple_orgs(
+        db_session, "multi@example.com", "TestPass1!"
+    )
+    login = client.post(
+        "/api/v1/auth/login",
+        json={
+            "email": "multi@example.com",
+            "password": "TestPass1!",
+            "organization_id": str(org_a.id),
+        },
+    )
+    assert login.status_code == 200
+    login_body = login.json()
+    login_claims = decode_access_token(login_body["access_token"])
+    assert set(login_claims["authenticated_org_ids"]) == {str(org_a.id), str(org_b.id)}
+
+    refreshed = client.post(
+        "/api/v1/auth/refresh",
+        json={"refresh_token": login_body["refresh_token"]},
+        headers={"Authorization": f"Bearer {login_body['access_token']}"},
+    )
+    assert refreshed.status_code == 200
+    refresh_claims = decode_access_token(refreshed.json()["access_token"])
+    assert set(refresh_claims["authenticated_org_ids"]) == {str(org_a.id), str(org_b.id)}
 
 
 def test_logout_revokes_access_and_refresh_tokens(

--- a/tests/test_api/test_auth_routes.py
+++ b/tests/test_api/test_auth_routes.py
@@ -661,7 +661,10 @@ def test_password_change_invalidates_existing_access_token(
 def test_switch_org_mints_token_for_target_org(
     client, db_session, enable_local_password
 ):
-    """Happy path: user is a member of two orgs and switches into the second."""
+    """Happy path: user authenticated for both orgs can switch into the second."""
+    from app.core.auth.org_credentials import provision_membership_credential, set_org_password_hash
+    from app.core.auth.tokens import decode_access_token
+
     user, source_org = _seed_user_with_org(
         db_session, "multi@example.com", "ThePass1!"
     )
@@ -676,29 +679,88 @@ def test_switch_org_mints_token_for_target_org(
             role=RoleEnum.READER.value,
         )
     )
+    db_session.flush()
+    target_cred = provision_membership_credential(
+        db_session, user_id=user.id, organization_id=target_org.id
+    )
+    set_org_password_hash(target_cred, hash_password("ThePass1!"))
     db_session.commit()
 
-    principal = Principal(
-        organization_id=source_org.id,
-        auth_method=AuthMethod.LOCAL_PASSWORD,
-        user_id=user.id,
-        email=user.email,
+    login = client.post(
+        "/api/v1/auth/login",
+        json={
+            "email": "multi@example.com",
+            "password": "ThePass1!",
+            "organization_id": str(source_org.id),
+        },
     )
-    _override_principal(client, principal)
-    try:
-        response = client.post(
-            "/api/v1/auth/switch-org",
-            json={"organization_id": str(target_org.id)},
-        )
-    finally:
-        _clear_principal_override(client)
+    assert login.status_code == 200
+    login_body = login.json()
+    claims = decode_access_token(login_body["access_token"])
+    assert str(target_org.id) in claims["authenticated_org_ids"]
+
+    response = client.post(
+        "/api/v1/auth/switch-org",
+        json={
+            "organization_id": str(target_org.id),
+            "refresh_token": login_body["refresh_token"],
+        },
+        headers={"Authorization": f"Bearer {login_body['access_token']}"},
+    )
 
     assert response.status_code == 200
     body = response.json()
     assert body["access_token"]
     assert body["user"]["organization_id"] == str(target_org.id)
-    # Role reflects the target-org membership, not the source-org role.
     assert body["user"]["role"] == RoleEnum.READER.value
+
+
+def test_switch_org_requires_reauth_when_target_not_authenticated(
+    client, db_session, enable_local_password
+):
+    from app.core.auth.org_credentials import provision_membership_credential, set_org_password_hash
+
+    user, source_org = _seed_user_with_org(
+        db_session, "multi@example.com", "ThePass1!"
+    )
+
+    target_org = Organization(id=uuid4(), name="Target Org")
+    db_session.add(target_org)
+    db_session.flush()
+    db_session.add(
+        OrganizationMember(
+            organization_id=target_org.id,
+            user_id=user.id,
+            role=RoleEnum.READER.value,
+        )
+    )
+    db_session.flush()
+    target_cred = provision_membership_credential(
+        db_session, user_id=user.id, organization_id=target_org.id
+    )
+    set_org_password_hash(target_cred, hash_password("OtherPass2!"))
+    db_session.commit()
+
+    login = client.post(
+        "/api/v1/auth/login",
+        json={
+            "email": "multi@example.com",
+            "password": "ThePass1!",
+            "organization_id": str(source_org.id),
+        },
+    ).json()
+
+    response = client.post(
+        "/api/v1/auth/switch-org",
+        json={
+            "organization_id": str(target_org.id),
+            "refresh_token": login["refresh_token"],
+        },
+        headers={"Authorization": f"Bearer {login['access_token']}"},
+    )
+
+    assert response.status_code == 403
+    assert "password" in response.json()["detail"].lower()
 
 
 def test_switch_org_rejects_api_key_caller_with_403(client, db_session, seed_org):
@@ -846,6 +908,67 @@ def test_refresh_preserves_authenticated_org_ids(client, db_session, enable_loca
         "/api/v1/auth/refresh",
         json={"refresh_token": login_body["refresh_token"]},
         headers={"Authorization": f"Bearer {login_body['access_token']}"},
+    )
+    assert refreshed.status_code == 200
+    refresh_claims = decode_access_token(refreshed.json()["access_token"])
+    assert set(refresh_claims["authenticated_org_ids"]) == {str(org_a.id), str(org_b.id)}
+
+
+def test_refresh_preserves_authenticated_org_ids_without_access_token(
+    client, db_session, enable_local_password
+):
+    from app.core.auth.tokens import decode_access_token
+
+    _user, org_a, org_b = _seed_user_with_multiple_orgs(
+        db_session, "multi@example.com", "TestPass1!"
+    )
+    login = client.post(
+        "/api/v1/auth/login",
+        json={
+            "email": "multi@example.com",
+            "password": "TestPass1!",
+            "organization_id": str(org_a.id),
+        },
+    ).json()
+
+    refreshed = client.post(
+        "/api/v1/auth/refresh",
+        json={"refresh_token": login["refresh_token"]},
+    )
+    assert refreshed.status_code == 200
+    refresh_claims = decode_access_token(refreshed.json()["access_token"])
+    assert set(refresh_claims["authenticated_org_ids"]) == {str(org_a.id), str(org_b.id)}
+
+
+def test_refresh_preserves_authenticated_org_ids_with_expired_access_token(
+    client, db_session, enable_local_password
+):
+    from app.core.auth.tokens import create_access_token, decode_access_token
+
+    user, org_a, org_b = _seed_user_with_multiple_orgs(
+        db_session, "multi@example.com", "TestPass1!"
+    )
+    login = client.post(
+        "/api/v1/auth/login",
+        json={
+            "email": "multi@example.com",
+            "password": "TestPass1!",
+            "organization_id": str(org_a.id),
+        },
+    ).json()
+
+    expired_token, _jti, _ttl = create_access_token(
+        user_id=user.id,
+        organization_id=org_a.id,
+        email=user.email,
+        authenticated_org_ids=[str(org_a.id), str(org_b.id)],
+        expires_in_minutes=-1,
+    )
+
+    refreshed = client.post(
+        "/api/v1/auth/refresh",
+        json={"refresh_token": login["refresh_token"]},
+        headers={"Authorization": f"Bearer {expired_token}"},
     )
     assert refreshed.status_code == 200
     refresh_claims = decode_access_token(refreshed.json()["access_token"])

--- a/tests/test_api/test_auth_routes.py
+++ b/tests/test_api/test_auth_routes.py
@@ -434,7 +434,7 @@ def test_login_with_organization_id_returns_scoped_token(
     assert body["user"]["role"] == RoleEnum.READER.value
 
 
-def test_login_rejects_invalid_organization_id_with_403(
+def test_login_rejects_invalid_organization_id_with_401(
     client, db_session, enable_local_password
 ):
     _seed_user_with_multiple_orgs(db_session, "multi@example.com", "TestPass1!")
@@ -448,8 +448,8 @@ def test_login_rejects_invalid_organization_id_with_403(
         },
     )
 
-    assert response.status_code == 403
-    assert "not a member" in response.json()["detail"].lower()
+    assert response.status_code == 401
+    assert "invalid email or password" in response.json()["detail"].lower()
 
 
 def test_provision_default_workspace_is_idempotent(db_session, org_id, seed_org):
@@ -587,8 +587,8 @@ def test_password_change_invalidates_existing_access_token(
     db_session, org_id, seed_org, enable_local_password,
 ):
     from app.core.auth.local import LocalPasswordProvider
+    from app.core.auth.org_credentials import bump_org_session_epoch, get_or_create_credential
     from app.core.auth.providers import AuthError, RawCredential, reset_provider_registry
-    from app.core.auth.session_epoch import bump_user_session_epoch
     from app.core.auth.tokens import create_access_token
 
     reset_provider_registry()
@@ -607,18 +607,23 @@ def test_password_change_invalidates_existing_access_token(
             role=RoleEnum.ADMIN.value,
         )
     )
+    db_session.flush()
+    credential = get_or_create_credential(
+        db_session, user_id=user.id, organization_id=org_id, user=user
+    )
+    credential.password_hash = user.password_hash
     db_session.commit()
 
     token, _, _ = create_access_token(
         user_id=user.id,
         organization_id=org_id,
         email=user.email,
-        session_epoch=user.session_epoch,
+        session_epoch=credential.session_epoch,
     )
     provider = LocalPasswordProvider()
     provider.authenticate(RawCredential(bearer_token=token), db_session)
 
-    bump_user_session_epoch(user)
+    bump_org_session_epoch(credential)
     db_session.commit()
 
     with pytest.raises(AuthError, match="Session expired"):

--- a/tests/test_api/test_auth_routes.py
+++ b/tests/test_api/test_auth_routes.py
@@ -1210,3 +1210,40 @@ def test_accept_invitation_by_token_issues_org_scoped_session(
         .count()
     )
     assert workspace_membership >= 1
+
+
+def test_oidc_session_rejects_removed_organization_member(
+    client, db_session, org_id
+):
+    from app.core.auth import get_principal
+    from tests.conftest import _SESSION_API_APP
+
+    user = User(
+        id=uuid4(),
+        email="removed-oidc@example.com",
+        is_active=True,
+        auth_provider="oidc",
+    )
+    db_session.add(user)
+    db_session.commit()
+
+    def _removed_member_principal():
+        return Principal(
+            organization_id=org_id,
+            auth_method=AuthMethod.EXTERNAL_OIDC,
+            user_id=user.id,
+            email=user.email,
+            token_sub="oidc-sub-removed",
+        )
+
+    _SESSION_API_APP.dependency_overrides[get_principal] = _removed_member_principal
+    try:
+        response = client.post(
+            "/api/v1/auth/oidc/session",
+            headers={"Authorization": "Bearer oidc-token"},
+        )
+    finally:
+        _SESSION_API_APP.dependency_overrides.pop(get_principal, None)
+
+    assert response.status_code == 403
+    assert "not a member" in response.json()["detail"].lower()

--- a/tests/test_api/test_evaluator_results_routes.py
+++ b/tests/test_api/test_evaluator_results_routes.py
@@ -1,5 +1,7 @@
 """API tests for evaluator results routes."""
 
+import pytest
+
 
 def test_derive_speaker_segments_supports_smallest_payload():
     from app.api.v1.routes.evaluator_results import _derive_speaker_segments_from_call_data
@@ -546,6 +548,7 @@ def test_stream_evaluator_result_audio_proxies_elevenlabs(
     make_integration,
     make_evaluator_result,
     monkeypatch,
+    mock_recording_hostname_dns,
 ):
     from app.models.enums import IntegrationPlatform
 
@@ -594,12 +597,24 @@ def test_stream_evaluator_result_audio_proxies_elevenlabs(
     assert captured["headers"]["xi-api-key"] == "test-xi-key"
 
 
+@pytest.fixture
+def mock_recording_hostname_dns(monkeypatch):
+    import app.services.telephony.recording_download as recording_download
+
+    monkeypatch.setattr(
+        recording_download.socket,
+        "getaddrinfo",
+        lambda *args, **kwargs: [(None, None, None, None, ("52.0.0.1", 0))],
+    )
+
+
 def test_stream_evaluator_result_audio_proxies_vapi_with_bearer(
     authenticated_client,
     make_agent,
     make_integration,
     make_evaluator_result,
     monkeypatch,
+    mock_recording_hostname_dns,
 ):
     from app.models.enums import IntegrationPlatform
 
@@ -643,9 +658,10 @@ def test_stream_evaluator_result_audio_proxies_vapi_with_bearer(
 def test_stream_evaluator_result_audio_redirects_vapi_presigned_url(
     authenticated_client,
     make_evaluator_result,
+    mock_recording_hostname_dns,
 ):
     signed_url = (
-        "https://hipaa-recordings.example/recording.wav?"
+        "https://hipaa-recordings.s3.amazonaws.com/recording.wav?"
         "X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Signature=abc"
     )
     make_evaluator_result(
@@ -655,7 +671,7 @@ def test_stream_evaluator_result_audio_redirects_vapi_presigned_url(
         call_data={
             "artifact": {
                 "presignedMonoUrl": signed_url,
-                "recordingUrl": "https://raw.example/recording.wav",
+                "recordingUrl": "https://bucket.s3.amazonaws.com/recording.wav",
             }
         },
     )
@@ -691,6 +707,7 @@ def test_re_evaluate_downloads_vapi_audio_with_bearer(
     make_evaluator,
     make_evaluator_result,
     monkeypatch,
+    mock_recording_hostname_dns,
 ):
     from app.models.enums import IntegrationPlatform
 

--- a/tests/test_api/test_iam_routes.py
+++ b/tests/test_api/test_iam_routes.py
@@ -197,3 +197,46 @@ def test_remove_user_clears_workspace_memberships(
         .first()
         is None
     )
+
+
+def test_remove_user_deletes_org_credential(
+    iam_admin_override,
+    authenticated_client,
+    db_session,
+    org_id,
+    make_user,
+):
+    from app.core.auth.org_credentials import get_credential, provision_membership_credential, set_org_password_hash
+    from app.core.password import hash_password
+    from app.models.database import OrganizationMemberCredential
+
+    member_user = make_user(email="credential-cleanup@example.com", name="Credential Cleanup")
+    db_session.add(
+        OrganizationMember(
+            organization_id=org_id,
+            user_id=member_user.id,
+            role=RoleEnum.READER.value,
+        )
+    )
+    db_session.flush()
+    credential = provision_membership_credential(
+        db_session, user_id=member_user.id, organization_id=org_id
+    )
+    set_org_password_hash(credential, hash_password("RemoveMe1!"))
+    db_session.commit()
+
+    assert get_credential(db_session, user_id=member_user.id, organization_id=org_id) is not None
+
+    response = authenticated_client.delete(f"/api/v1/iam/users/{member_user.id}")
+    assert response.status_code == 204
+
+    assert get_credential(db_session, user_id=member_user.id, organization_id=org_id) is None
+    assert (
+        db_session.query(OrganizationMemberCredential)
+        .filter(
+            OrganizationMemberCredential.organization_id == org_id,
+            OrganizationMemberCredential.user_id == member_user.id,
+        )
+        .first()
+        is None
+    )

--- a/tests/test_api/test_iam_routes.py
+++ b/tests/test_api/test_iam_routes.py
@@ -71,6 +71,16 @@ def test_list_invitations_excludes_accepted(
     assert "accepted@example.com" not in emails
 
 
+def test_invite_duplicate_pending_returns_conflict(iam_admin_override, authenticated_client):
+    payload = {"email": "dup@example.com", "role": "reader"}
+    first = authenticated_client.post("/api/v1/iam/invitations", json=payload)
+    assert first.status_code == 201
+
+    second = authenticated_client.post("/api/v1/iam/invitations", json=payload)
+    assert second.status_code == 409
+    assert second.json()["detail"] == "An invitation is already pending for this email"
+
+
 def test_update_user_role(iam_admin_override, authenticated_client, db_session, org_id, make_user):
     user_to_update = make_user(email="reader@example.com", name="Reader User")
     membership = OrganizationMember(

--- a/tests/test_api/test_iam_routes.py
+++ b/tests/test_api/test_iam_routes.py
@@ -140,3 +140,60 @@ def test_update_organization_rejects_empty_name(iam_admin_override, authenticate
     )
 
     assert response.status_code == 422
+
+
+def test_remove_user_clears_workspace_memberships(
+    iam_admin_override,
+    authenticated_client,
+    db_session,
+    org_id,
+    make_user,
+    default_workspace,
+):
+    from app.models.database import Workspace, WorkspaceMember
+    from app.services.workspace_rbac import backfill_org_workspace_memberships
+
+    member_user = make_user(email="remove-me@example.com", name="Remove Me")
+    db_session.add(
+        OrganizationMember(
+            organization_id=org_id,
+            user_id=member_user.id,
+            role=RoleEnum.READER.value,
+        )
+    )
+    db_session.commit()
+    backfill_org_workspace_memberships(db_session, organization_id=org_id)
+
+    assert (
+        db_session.query(WorkspaceMember)
+        .join(Workspace, Workspace.id == WorkspaceMember.workspace_id)
+        .filter(
+            Workspace.organization_id == org_id,
+            WorkspaceMember.user_id == member_user.id,
+        )
+        .count()
+        == 1
+    )
+
+    response = authenticated_client.delete(f"/api/v1/iam/users/{member_user.id}")
+    assert response.status_code == 204
+
+    assert (
+        db_session.query(WorkspaceMember)
+        .join(Workspace, Workspace.id == WorkspaceMember.workspace_id)
+        .filter(
+            Workspace.organization_id == org_id,
+            WorkspaceMember.user_id == member_user.id,
+        )
+        .count()
+        == 0
+    )
+    assert (
+        db_session.query(OrganizationMember)
+        .filter(
+            OrganizationMember.organization_id == org_id,
+            OrganizationMember.user_id == member_user.id,
+        )
+        .first()
+        is None
+    )

--- a/tests/test_api/test_iam_routes.py
+++ b/tests/test_api/test_iam_routes.py
@@ -5,8 +5,17 @@ from uuid import uuid4
 
 import pytest
 
+from app.config import settings
 from app.models.database import Invitation, OrganizationMember
 from app.models.enums import InvitationStatus, RoleEnum
+
+
+@pytest.fixture
+def enable_local_password(monkeypatch):
+    monkeypatch.setattr(settings, "AUTH_PROVIDERS", ["api_key", "local_password"])
+    monkeypatch.setattr(settings, "AUTH_LOCAL_ALLOW_SIGNUP", True)
+    monkeypatch.setattr(settings, "AUTH_GATED_SIGNUP_ENABLED", False)
+    return settings
 
 
 @pytest.fixture
@@ -206,7 +215,12 @@ def test_remove_user_deletes_org_credential(
     org_id,
     make_user,
 ):
-    from app.core.auth.org_credentials import get_credential, provision_membership_credential, set_org_password_hash
+    from app.core.auth.org_credentials import (
+        get_credential,
+        get_session_revocation_floor,
+        provision_membership_credential,
+        set_org_password_hash,
+    )
     from app.core.password import hash_password
     from app.models.database import OrganizationMemberCredential
 
@@ -240,3 +254,88 @@ def test_remove_user_deletes_org_credential(
         .first()
         is None
     )
+    assert get_session_revocation_floor(
+        db_session, user_id=member_user.id, organization_id=org_id
+    ) >= 1
+
+
+def test_removed_member_reinvite_does_not_reactivate_old_access_token(
+    iam_admin_override,
+    authenticated_client,
+    client,
+    db_session,
+    org_id,
+    make_user,
+    user_context,
+    enable_local_password,
+):
+    from datetime import datetime, timedelta, timezone
+
+    import pytest
+
+    from app.core.auth.local import LocalPasswordProvider
+    from app.core.auth.org_credentials import get_credential, set_org_password_hash
+    from app.core.auth.providers import AuthError, RawCredential, reset_provider_registry
+    from app.models.database import Invitation, InvitationStatus
+    from app.services.invitation_service import accept_invitation
+    from app.services.organization_provisioning import provision_default_workspace
+    from app.core.auth.org_credentials import provision_membership_credential
+    from app.core.password import hash_password
+
+    password = "ReturnPass1!"
+    member_user = make_user(email="returning@example.com", name="Returning User")
+    db_session.add(
+        OrganizationMember(
+            organization_id=org_id,
+            user_id=member_user.id,
+            role=RoleEnum.READER.value,
+        )
+    )
+    db_session.flush()
+    credential = provision_membership_credential(
+        db_session, user_id=member_user.id, organization_id=org_id
+    )
+    set_org_password_hash(credential, hash_password(password))
+    db_session.commit()
+
+    login = client.post(
+        "/api/v1/auth/login",
+        json={
+            "email": member_user.email,
+            "password": password,
+            "organization_id": str(org_id),
+        },
+    )
+    assert login.status_code == 200
+    old_access_token = login.json()["access_token"]
+
+    removed = authenticated_client.delete(f"/api/v1/iam/users/{member_user.id}")
+    assert removed.status_code == 204
+
+    provision_default_workspace(
+        db_session,
+        organization_id=org_id,
+        created_by_user_id=user_context["user"].id,
+    )
+    invitation = Invitation(
+        organization_id=org_id,
+        invited_by_id=user_context["user"].id,
+        email=member_user.email,
+        role=RoleEnum.READER.value,
+        status=InvitationStatus.PENDING.value,
+        token="returning-member",
+        expires_at=datetime.now(timezone.utc) + timedelta(days=7),
+    )
+    db_session.add(invitation)
+    db_session.commit()
+
+    accept_invitation(db_session, invitation, member_user)
+
+    restored = get_credential(db_session, user_id=member_user.id, organization_id=org_id)
+    assert restored is not None
+    assert restored.session_epoch >= 1
+
+    provider = LocalPasswordProvider()
+    reset_provider_registry()
+    with pytest.raises(AuthError):
+        provider.authenticate(RawCredential(bearer_token=old_access_token), db_session)

--- a/tests/test_api/test_llm_gateway_settings.py
+++ b/tests/test_api/test_llm_gateway_settings.py
@@ -54,8 +54,9 @@ def test_get_llm_gateway_settings_defaults(authenticated_client):
 
 
 def test_update_llm_gateway_settings_persists_bifrost_override(
-    authenticated_client, db_session, org_id
+    authenticated_client, db_session, org_id, monkeypatch
 ):
+    monkeypatch.setattr(settings, "DEBUG", True)
     _set_platform_gateway(enabled=False)
 
     response = authenticated_client.put(
@@ -63,7 +64,7 @@ def test_update_llm_gateway_settings_persists_bifrost_override(
         json={
             "mode": "enabled",
             "gateway_type": "bifrost",
-            "base_url": "http://org-bifrost:8080/litellm",
+            "base_url": "http://127.0.0.1:8080/litellm",
             "virtual_key": "org-virtual-key",
         },
     )
@@ -71,10 +72,10 @@ def test_update_llm_gateway_settings_persists_bifrost_override(
     data = response.json()
     assert data["mode"] == "enabled"
     assert data["gateway_type"] == "bifrost"
-    assert data["base_url"] == "http://org-bifrost:8080/litellm"
+    assert data["base_url"] == "http://127.0.0.1:8080/litellm"
     assert data["has_virtual_key"] is True
     assert data["effective_routing"] == "bifrost"
-    assert data["effective_base_url"] == "http://org-bifrost:8080/litellm"
+    assert data["effective_base_url"] == "http://127.0.0.1:8080/litellm"
 
     org = db_session.query(Organization).filter(Organization.id == org_id).first()
     assert org.llm_gateway_settings["enabled"] is True
@@ -83,8 +84,9 @@ def test_update_llm_gateway_settings_persists_bifrost_override(
 
 
 def test_update_llm_gateway_settings_persists_litellm_proxy_override(
-    authenticated_client, db_session, org_id
+    authenticated_client, db_session, org_id, monkeypatch
 ):
+    monkeypatch.setattr(settings, "DEBUG", True)
     _set_platform_gateway(enabled=False)
 
     response = authenticated_client.put(
@@ -92,7 +94,7 @@ def test_update_llm_gateway_settings_persists_litellm_proxy_override(
         json={
             "mode": "enabled",
             "gateway_type": "litellm_proxy",
-            "base_url": "http://org-proxy:4000",
+            "base_url": "http://127.0.0.1:4000",
             "master_key": "org-master-key",
         },
     )
@@ -101,7 +103,7 @@ def test_update_llm_gateway_settings_persists_litellm_proxy_override(
     assert data["gateway_type"] == "litellm_proxy"
     assert data["has_master_key"] is True
     assert data["effective_routing"] == "litellm_proxy"
-    assert data["effective_base_url"] == "http://org-proxy:4000"
+    assert data["effective_base_url"] == "http://127.0.0.1:4000"
 
     org = db_session.query(Organization).filter(Organization.id == org_id).first()
     assert org.llm_gateway_settings["gateway_type"] == "litellm_proxy"

--- a/tests/test_api/test_org_credentials.py
+++ b/tests/test_api/test_org_credentials.py
@@ -511,3 +511,38 @@ def test_accept_invitation_skips_inheritance_when_org_passwords_differ(db_sessio
     )
     assert invited_cred is not None
     assert invited_cred.password_hash is None
+
+
+def test_resolve_current_password_hash_ignores_legacy_when_credential_row_exists(db_session):
+    from app.models.database import OrganizationMemberCredential
+
+    from app.core.auth.org_credentials import (
+        resolve_current_password_hash,
+        set_org_password_hash,
+    )
+
+    user = User(
+        id=uuid4(),
+        email="legacy-rotation@example.com",
+        password_hash=hash_password("LegacyPass1!"),
+        is_active=True,
+        auth_provider="local",
+    )
+    org = Organization(id=uuid4(), name="Org")
+    db_session.add_all([user, org])
+    db_session.flush()
+    db_session.add(
+        OrganizationMember(organization_id=org.id, user_id=user.id, role=RoleEnum.ADMIN.value)
+    )
+    db_session.flush()
+    credential = OrganizationMemberCredential(
+        organization_id=org.id,
+        user_id=user.id,
+        password_hash=None,
+        session_epoch=0,
+    )
+    db_session.add(credential)
+    db_session.flush()
+    assert resolve_current_password_hash(credential, user) is None
+    set_org_password_hash(credential, hash_password("OrgOnlyPass1!"))
+    assert resolve_current_password_hash(credential, user) == credential.password_hash

--- a/tests/test_api/test_org_credentials.py
+++ b/tests/test_api/test_org_credentials.py
@@ -726,3 +726,71 @@ def test_resolve_current_password_hash_ignores_legacy_when_credential_row_exists
     assert resolve_current_password_hash(credential, user) is None
     set_org_password_hash(credential, hash_password("OrgOnlyPass1!"))
     assert resolve_current_password_hash(credential, user) == credential.password_hash
+
+
+def test_concurrent_session_revocation_insert_is_idempotent(test_engine):
+    from sqlalchemy.orm import sessionmaker
+
+    from app.core.auth.org_credentials import (
+        get_session_revocation_floor,
+        record_org_membership_session_revocation,
+    )
+    from app.models.database import OrganizationMemberCredential
+
+    org_id = uuid4()
+    user_id = uuid4()
+    org = Organization(id=org_id, name="Concurrent Org")
+    user = User(
+        id=user_id,
+        email="concurrent-revoke@example.com",
+        password_hash=hash_password("Concurrent1!"),
+        is_active=True,
+        auth_provider="local",
+    )
+
+    setup = sessionmaker(bind=test_engine)()
+    setup.add_all([org, user])
+    setup.commit()
+    setup.close()
+
+    conn1 = test_engine.connect()
+    conn2 = test_engine.connect()
+    trans1 = conn1.begin()
+    trans2 = conn2.begin()
+    session1 = sessionmaker(bind=conn1)()
+    session2 = sessionmaker(bind=conn2)()
+
+    credential = OrganizationMemberCredential(
+        organization_id=org_id,
+        user_id=user_id,
+        password_hash=None,
+        session_epoch=0,
+    )
+    session1.add(credential)
+    session1.flush()
+
+    floor1 = record_org_membership_session_revocation(
+        session1,
+        user_id=user_id,
+        organization_id=org_id,
+        credential=credential,
+    )
+    floor2 = record_org_membership_session_revocation(
+        session2,
+        user_id=user_id,
+        organization_id=org_id,
+        credential=credential,
+    )
+
+    assert floor1 == 1
+    assert floor2 == 1
+    trans1.commit()
+    trans2.commit()
+    conn1.close()
+    conn2.close()
+
+    verify = sessionmaker(bind=test_engine)()
+    assert (
+        get_session_revocation_floor(verify, user_id=user_id, organization_id=org_id) == 1
+    )
+    verify.close()

--- a/tests/test_api/test_org_credentials.py
+++ b/tests/test_api/test_org_credentials.py
@@ -448,6 +448,89 @@ def test_accept_invitation_uses_source_org_password_not_oldest(db_session):
     assert {org.id for _, org in matched_a} == {org_a.id}
 
 
+def test_build_invite_join_notice_mentions_source_when_passwords_match(db_session):
+    from app.core.auth.org_credentials import (
+        provision_membership_credential,
+        set_org_password_hash,
+    )
+    from app.services.invitation_service import build_invite_join_notice
+
+    password_hash = hash_password("SharedPass1!")
+    org_a = Organization(id=uuid4(), name="Org A")
+    invited_org = Organization(id=uuid4(), name="Invited Org")
+    user = User(
+        id=uuid4(),
+        email="invitee@example.com",
+        is_active=True,
+        auth_provider="local",
+    )
+    db_session.add_all([org_a, invited_org, user])
+    db_session.flush()
+    cred_a = provision_membership_credential(
+        db_session, user_id=user.id, organization_id=org_a.id, user=user
+    )
+    invited_cred = provision_membership_credential(
+        db_session, user_id=user.id, organization_id=invited_org.id, user=user
+    )
+    set_org_password_hash(cred_a, password_hash)
+    set_org_password_hash(invited_cred, password_hash)
+    db_session.commit()
+
+    notice = build_invite_join_notice(
+        db_session,
+        user=user,
+        organization_id=invited_org.id,
+        organization_name=invited_org.name,
+        source_organization_id=org_a.id,
+    )
+
+    assert notice is not None
+    assert "Org A" in notice
+    assert "same password" in notice.lower()
+
+
+def test_build_invite_join_notice_does_not_claim_source_password_when_hashes_differ(
+    db_session,
+):
+    from app.core.auth.org_credentials import (
+        provision_membership_credential,
+        set_org_password_hash,
+    )
+    from app.services.invitation_service import build_invite_join_notice
+
+    org_a = Organization(id=uuid4(), name="Org A")
+    invited_org = Organization(id=uuid4(), name="Invited Org")
+    user = User(
+        id=uuid4(),
+        email="invitee@example.com",
+        is_active=True,
+        auth_provider="local",
+    )
+    db_session.add_all([org_a, invited_org, user])
+    db_session.flush()
+    cred_a = provision_membership_credential(
+        db_session, user_id=user.id, organization_id=org_a.id, user=user
+    )
+    invited_cred = provision_membership_credential(
+        db_session, user_id=user.id, organization_id=invited_org.id, user=user
+    )
+    set_org_password_hash(cred_a, hash_password("OrgAPass1!"))
+    set_org_password_hash(invited_cred, hash_password("InvitedPass1!"))
+    db_session.commit()
+
+    notice = build_invite_join_notice(
+        db_session,
+        user=user,
+        organization_id=invited_org.id,
+        organization_name=invited_org.name,
+        source_organization_id=org_a.id,
+    )
+
+    assert notice is not None
+    assert "Org A" not in notice
+    assert "this organization" in notice.lower()
+
+
 def test_accept_invitation_skips_inheritance_when_org_passwords_differ(db_session):
     from datetime import datetime, timedelta, timezone
 

--- a/tests/test_api/test_org_credentials.py
+++ b/tests/test_api/test_org_credentials.py
@@ -154,6 +154,103 @@ def test_admin_reset_password_only_invalidates_target_org_session(
     assert login_user_b_old.status_code == 200
 
 
+def test_other_org_password_reset_revokes_cross_org_refresh_authorization(
+    client, db_session, enable_local_password
+):
+    from app.core.auth.org_credentials import provision_membership_credential, set_org_password_hash
+    from app.core.auth.tokens import decode_access_token
+
+    org_a = Organization(id=uuid4(), name="Org A")
+    org_b = Organization(id=uuid4(), name="Org B")
+    user = User(
+        id=uuid4(),
+        email="cross-org-auth@example.com",
+        password_hash=hash_password("SharedPass1!"),
+        is_active=True,
+        auth_provider="local",
+    )
+    db_session.add_all([org_a, org_b, user])
+    db_session.flush()
+    db_session.add_all(
+        [
+            OrganizationMember(organization_id=org_a.id, user_id=user.id, role=RoleEnum.READER.value),
+            OrganizationMember(organization_id=org_b.id, user_id=user.id, role=RoleEnum.READER.value),
+        ]
+    )
+    db_session.flush()
+    for org in (org_a, org_b):
+        credential = provision_membership_credential(
+            db_session, user_id=user.id, organization_id=org.id, user=user
+        )
+        set_org_password_hash(credential, user.password_hash)
+    db_session.commit()
+
+    login_a = client.post(
+        "/api/v1/auth/login",
+        json={
+            "email": user.email,
+            "password": "SharedPass1!",
+            "organization_id": str(org_a.id),
+        },
+    )
+    assert login_a.status_code == 200
+    login_body = login_a.json()
+    login_claims = decode_access_token(login_body["access_token"])
+    assert set(login_claims["authenticated_org_ids"]) == {str(org_a.id), str(org_b.id)}
+    assert login_claims["authenticated_org_epochs"][str(org_b.id)] == 0
+
+    from app.core.auth.org_credentials import bump_org_session_epoch, get_credential
+    from app.core.auth.refresh_tokens import (
+        revoke_refresh_tokens_for_user_org,
+        strip_org_from_user_refresh_auth,
+    )
+
+    cred_b = get_credential(db_session, user_id=user.id, organization_id=org_b.id)
+    set_org_password_hash(cred_b, hash_password("ResetInB1!"))
+    bump_org_session_epoch(cred_b)
+    strip_org_from_user_refresh_auth(
+        db_session,
+        user_id=user.id,
+        organization_id=org_b.id,
+    )
+    revoke_refresh_tokens_for_user_org(
+        db_session,
+        user_id=user.id,
+        organization_id=org_b.id,
+    )
+    db_session.commit()
+
+    switch_before_refresh = client.post(
+        "/api/v1/auth/switch-org",
+        json={
+            "organization_id": str(org_b.id),
+            "refresh_token": login_body["refresh_token"],
+        },
+        headers={"Authorization": f"Bearer {login_body['access_token']}"},
+    )
+    assert switch_before_refresh.status_code == 403
+
+    refreshed = client.post(
+        "/api/v1/auth/refresh",
+        json={"refresh_token": login_body["refresh_token"]},
+        headers={"Authorization": f"Bearer {login_body['access_token']}"},
+    )
+    assert refreshed.status_code == 200
+    refresh_claims = decode_access_token(refreshed.json()["access_token"])
+    assert refresh_claims["authenticated_org_ids"] == [str(org_a.id)]
+    assert str(org_b.id) not in refresh_claims.get("authenticated_org_epochs", {})
+
+    switch_after_refresh = client.post(
+        "/api/v1/auth/switch-org",
+        json={
+            "organization_id": str(org_b.id),
+            "refresh_token": refreshed.json()["refresh_token"],
+        },
+        headers={"Authorization": f"Bearer {refreshed.json()['access_token']}"},
+    )
+    assert switch_after_refresh.status_code == 403
+
+
 def test_login_only_unlocks_orgs_with_matching_password(
     client, db_session, enable_local_password
 ):

--- a/tests/test_api/test_org_credentials.py
+++ b/tests/test_api/test_org_credentials.py
@@ -300,3 +300,68 @@ def test_password_change_invalidates_only_current_org_session(
     with pytest.raises(AuthError, match="Session expired"):
         provider.authenticate(RawCredential(bearer_token=token_current), db_session)
     provider.authenticate(RawCredential(bearer_token=token_other), db_session)
+
+
+def test_accept_invitation_inherits_existing_org_password(db_session):
+    from datetime import datetime, timedelta, timezone
+
+    from app.core.auth.org_credentials import (
+        get_credential,
+        match_password_memberships,
+        provision_membership_credential,
+        set_org_password_hash,
+    )
+    from app.models.database import Invitation, InvitationStatus
+    from app.services.invitation_service import accept_invitation
+    from app.services.organization_provisioning import provision_default_workspace
+
+    password = "InvitePass1!"
+    home_org = Organization(id=uuid4(), name="Home Org")
+    invited_org = Organization(id=uuid4(), name="Invited Org")
+    inviter = User(id=uuid4(), email="inviter@example.com", is_active=True)
+    user = User(
+        id=uuid4(),
+        email="invitee@example.com",
+        password_hash=hash_password(password),
+        is_active=True,
+        auth_provider="local",
+    )
+    db_session.add_all([home_org, invited_org, inviter, user])
+    db_session.flush()
+    db_session.add(
+        OrganizationMember(organization_id=home_org.id, user_id=user.id, role=RoleEnum.ADMIN.value)
+    )
+    db_session.flush()
+    home_cred = provision_membership_credential(
+        db_session, user_id=user.id, organization_id=home_org.id, user=user
+    )
+    set_org_password_hash(home_cred, user.password_hash)
+    provision_default_workspace(
+        db_session,
+        organization_id=invited_org.id,
+        created_by_user_id=inviter.id,
+    )
+
+    invitation = Invitation(
+        organization_id=invited_org.id,
+        invited_by_id=inviter.id,
+        email=user.email,
+        role=RoleEnum.WRITER.value,
+        status=InvitationStatus.PENDING.value,
+        token="invite-inherit",
+        expires_at=datetime.now(timezone.utc) + timedelta(days=7),
+    )
+    db_session.add(invitation)
+    db_session.commit()
+
+    accept_invitation(db_session, invitation, user)
+
+    invited_cred = get_credential(
+        db_session, user_id=user.id, organization_id=invited_org.id
+    )
+    assert invited_cred is not None
+    assert invited_cred.password_hash == home_cred.password_hash
+    assert verify_password(password, invited_cred.password_hash)
+
+    matched = match_password_memberships(db_session, user=user, password=password)
+    assert {org.id for _, org in matched} == {home_org.id, invited_org.id}

--- a/tests/test_api/test_org_credentials.py
+++ b/tests/test_api/test_org_credentials.py
@@ -728,9 +728,8 @@ def test_resolve_current_password_hash_ignores_legacy_when_credential_row_exists
     assert resolve_current_password_hash(credential, user) == credential.password_hash
 
 
-def test_concurrent_session_revocation_insert_is_idempotent(test_engine):
-    from sqlalchemy.orm import sessionmaker
-
+def test_session_revocation_upsert_is_idempotent(db_session):
+    """Repeat revocation upserts must not deadlock or raise on PostgreSQL."""
     from app.core.auth.org_credentials import (
         get_session_revocation_floor,
         record_org_membership_session_revocation,
@@ -739,26 +738,16 @@ def test_concurrent_session_revocation_insert_is_idempotent(test_engine):
 
     org_id = uuid4()
     user_id = uuid4()
-    org = Organization(id=org_id, name="Concurrent Org")
+    org = Organization(id=org_id, name="Revocation Upsert Org")
     user = User(
         id=user_id,
-        email="concurrent-revoke@example.com",
+        email=f"revocation-upsert-{uuid4()}@example.com",
         password_hash=hash_password("Concurrent1!"),
         is_active=True,
         auth_provider="local",
     )
-
-    setup = sessionmaker(bind=test_engine)()
-    setup.add_all([org, user])
-    setup.commit()
-    setup.close()
-
-    conn1 = test_engine.connect()
-    conn2 = test_engine.connect()
-    trans1 = conn1.begin()
-    trans2 = conn2.begin()
-    session1 = sessionmaker(bind=conn1)()
-    session2 = sessionmaker(bind=conn2)()
+    db_session.add_all([org, user])
+    db_session.flush()
 
     credential = OrganizationMemberCredential(
         organization_id=org_id,
@@ -766,17 +755,17 @@ def test_concurrent_session_revocation_insert_is_idempotent(test_engine):
         password_hash=None,
         session_epoch=0,
     )
-    session1.add(credential)
-    session1.flush()
+    db_session.add(credential)
+    db_session.flush()
 
     floor1 = record_org_membership_session_revocation(
-        session1,
+        db_session,
         user_id=user_id,
         organization_id=org_id,
         credential=credential,
     )
     floor2 = record_org_membership_session_revocation(
-        session2,
+        db_session,
         user_id=user_id,
         organization_id=org_id,
         credential=credential,
@@ -784,13 +773,9 @@ def test_concurrent_session_revocation_insert_is_idempotent(test_engine):
 
     assert floor1 == 1
     assert floor2 == 1
-    trans1.commit()
-    trans2.commit()
-    conn1.close()
-    conn2.close()
-
-    verify = sessionmaker(bind=test_engine)()
     assert (
-        get_session_revocation_floor(verify, user_id=user_id, organization_id=org_id) == 1
+        get_session_revocation_floor(
+            db_session, user_id=user_id, organization_id=org_id
+        )
+        == 1
     )
-    verify.close()

--- a/tests/test_api/test_org_credentials.py
+++ b/tests/test_api/test_org_credentials.py
@@ -1,0 +1,231 @@
+"""Tests for org-scoped passwords and admin reset."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from app.core.auth.local import LocalPasswordProvider
+from app.core.auth.org_credentials import get_or_create_credential
+from app.core.auth.providers import AuthError, RawCredential, reset_provider_registry
+from app.core.auth.refresh_tokens import issue_refresh_token
+from app.core.auth.tokens import create_access_token
+from app.core.password import hash_password, verify_password
+from app.models.database import Organization, OrganizationMember, RoleEnum, User
+
+
+@pytest.fixture
+def enable_local_password(monkeypatch):
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "AUTH_PROVIDERS", ["api_key", "local_password"])
+    monkeypatch.setattr(settings, "AUTH_LOCAL_ALLOW_SIGNUP", True)
+
+
+def _seed_multi_org_user(db_session, email: str, password: str):
+    org_a = Organization(id=uuid4(), name="Org A")
+    org_b = Organization(id=uuid4(), name="Org B")
+    user = User(
+        id=uuid4(),
+        email=email,
+        password_hash=hash_password(password),
+        is_active=True,
+        auth_provider="local",
+    )
+    db_session.add_all([org_a, org_b, user])
+    db_session.flush()
+    db_session.add_all(
+        [
+            OrganizationMember(organization_id=org_a.id, user_id=user.id, role=RoleEnum.ADMIN.value),
+            OrganizationMember(organization_id=org_b.id, user_id=user.id, role=RoleEnum.READER.value),
+        ]
+    )
+    db_session.flush()
+    cred_a = get_or_create_credential(
+        db_session, user_id=user.id, organization_id=org_a.id, user=user
+    )
+    cred_b = get_or_create_credential(
+        db_session, user_id=user.id, organization_id=org_b.id, user=user
+    )
+    cred_a.password_hash = user.password_hash
+    cred_b.password_hash = user.password_hash
+    db_session.commit()
+    return user, org_a, org_b, cred_a, cred_b
+
+
+def test_admin_reset_password_only_invalidates_target_org_session(
+    client, db_session, org_id, seed_org, enable_local_password
+):
+    org_b = Organization(id=uuid4(), name="Org B")
+    user = User(
+        id=uuid4(),
+        email="multi-reset@example.com",
+        password_hash=hash_password("Original1!"),
+        is_active=True,
+        auth_provider="local",
+    )
+    db_session.add_all([org_b, user])
+    db_session.flush()
+    db_session.add_all(
+        [
+            OrganizationMember(organization_id=org_id, user_id=user.id, role=RoleEnum.READER.value),
+            OrganizationMember(organization_id=org_b.id, user_id=user.id, role=RoleEnum.READER.value),
+        ]
+    )
+    db_session.flush()
+    cred_a = get_or_create_credential(
+        db_session, user_id=user.id, organization_id=org_id, user=user
+    )
+    cred_b = get_or_create_credential(
+        db_session, user_id=user.id, organization_id=org_b.id, user=user
+    )
+    cred_a.password_hash = user.password_hash
+    cred_b.password_hash = user.password_hash
+    org_a_id = org_id
+
+    admin = User(
+        id=uuid4(),
+        email="admin-reset@example.com",
+        password_hash=hash_password("AdminPass1!"),
+        is_active=True,
+        auth_provider="local",
+    )
+    db_session.add(admin)
+    db_session.flush()
+    db_session.add(
+        OrganizationMember(
+            organization_id=org_a_id,
+            user_id=admin.id,
+            role=RoleEnum.ADMIN.value,
+        )
+    )
+    db_session.commit()
+
+    login_admin = client.post(
+        "/api/v1/auth/login",
+        json={"email": admin.email, "password": "AdminPass1!", "organization_id": str(org_a_id)},
+    )
+    assert login_admin.status_code == 200
+    admin_token = login_admin.json()["access_token"]
+
+    login_user_b = client.post(
+        "/api/v1/auth/login",
+        json={"email": user.email, "password": "Original1!", "organization_id": str(org_b.id)},
+    )
+    assert login_user_b.status_code == 200
+    user_b_token = login_user_b.json()["access_token"]
+
+    reset = client.post(
+        f"/api/v1/iam/users/{user.id}/reset-password",
+        headers={"Authorization": f"Bearer {admin_token}"},
+        json={"new_password": "ResetInA1!"},
+    )
+    assert reset.status_code == 200
+
+    db_session.refresh(cred_a)
+    db_session.refresh(cred_b)
+    assert verify_password("ResetInA1!", cred_a.password_hash)
+    assert verify_password("Original1!", cred_b.password_hash)
+    assert cred_a.session_epoch == 1
+    assert cred_b.session_epoch == 0
+
+    provider = LocalPasswordProvider()
+    reset_provider_registry()
+    provider.authenticate(RawCredential(bearer_token=user_b_token), db_session)
+
+    login_user_a = client.post(
+        "/api/v1/auth/login",
+        json={"email": user.email, "password": "ResetInA1!", "organization_id": str(org_a_id)},
+    )
+    assert login_user_a.status_code == 200
+
+    login_user_b_old = client.post(
+        "/api/v1/auth/login",
+        json={"email": user.email, "password": "Original1!", "organization_id": str(org_b.id)},
+    )
+    assert login_user_b_old.status_code == 200
+
+
+def test_login_only_unlocks_orgs_with_matching_password(
+    client, db_session, enable_local_password
+):
+    user, org_a, org_b, _cred_a, cred_b = _seed_multi_org_user(
+        db_session, "picker@example.com", "SharedPass1!"
+    )
+    cred_b.password_hash = hash_password("Different2!")
+    db_session.commit()
+
+    login_a = client.post(
+        "/api/v1/auth/login",
+        json={"email": user.email, "password": "SharedPass1!", "organization_id": str(org_a.id)},
+    )
+    assert login_a.status_code == 200
+    assert login_a.json()["access_token"]
+
+    login_b = client.post(
+        "/api/v1/auth/login",
+        json={"email": user.email, "password": "SharedPass1!", "organization_id": str(org_b.id)},
+    )
+    assert login_b.status_code == 401
+
+
+def test_password_change_invalidates_only_current_org_session(
+    db_session, org_id, seed_org, enable_local_password, client
+):
+    from app.core.auth.org_credentials import bump_org_session_epoch
+
+    reset_provider_registry()
+    other_org = Organization(id=uuid4(), name="Other Org")
+    user = User(
+        id=uuid4(),
+        email="epoch-org@example.com",
+        password_hash=hash_password("Original1!"),
+        is_active=True,
+        session_epoch=0,
+        auth_provider="local",
+    )
+    db_session.add_all([other_org, user])
+    db_session.flush()
+    db_session.add_all(
+        [
+            OrganizationMember(organization_id=org_id, user_id=user.id, role=RoleEnum.ADMIN.value),
+            OrganizationMember(organization_id=other_org.id, user_id=user.id, role=RoleEnum.READER.value),
+        ]
+    )
+    db_session.flush()
+    cred_current = get_or_create_credential(
+        db_session, user_id=user.id, organization_id=org_id, user=user
+    )
+    cred_other = get_or_create_credential(
+        db_session, user_id=user.id, organization_id=other_org.id, user=user
+    )
+    cred_current.password_hash = user.password_hash
+    cred_other.password_hash = user.password_hash
+    db_session.commit()
+
+    token_current, _, _ = create_access_token(
+        user_id=user.id,
+        organization_id=org_id,
+        email=user.email,
+        session_epoch=cred_current.session_epoch,
+        authenticated_org_ids=[str(org_id), str(other_org.id)],
+    )
+    token_other, _, _ = create_access_token(
+        user_id=user.id,
+        organization_id=other_org.id,
+        email=user.email,
+        session_epoch=cred_other.session_epoch,
+        authenticated_org_ids=[str(org_id), str(other_org.id)],
+    )
+
+    provider = LocalPasswordProvider()
+    provider.authenticate(RawCredential(bearer_token=token_current), db_session)
+    provider.authenticate(RawCredential(bearer_token=token_other), db_session)
+
+    bump_org_session_epoch(cred_current)
+    db_session.commit()
+
+    with pytest.raises(AuthError, match="Session expired"):
+        provider.authenticate(RawCredential(bearer_token=token_current), db_session)
+    provider.authenticate(RawCredential(bearer_token=token_other), db_session)

--- a/tests/test_api/test_org_credentials.py
+++ b/tests/test_api/test_org_credentials.py
@@ -365,3 +365,149 @@ def test_accept_invitation_inherits_existing_org_password(db_session):
 
     matched = match_password_memberships(db_session, user=user, password=password)
     assert {org.id for _, org in matched} == {home_org.id, invited_org.id}
+
+
+def test_accept_invitation_uses_source_org_password_not_oldest(db_session):
+    from datetime import datetime, timedelta, timezone
+
+    from app.core.auth.org_credentials import (
+        get_credential,
+        match_password_memberships,
+        provision_membership_credential,
+        set_org_password_hash,
+    )
+    from app.models.database import Invitation, InvitationStatus
+    from app.services.invitation_service import accept_invitation
+    from app.services.organization_provisioning import provision_default_workspace
+
+    password_a = "OrgAPass1!"
+    password_b = "OrgBPass1!"
+    org_a = Organization(id=uuid4(), name="Org A")
+    org_b = Organization(id=uuid4(), name="Org B")
+    invited_org = Organization(id=uuid4(), name="Invited Org")
+    inviter = User(id=uuid4(), email="inviter@example.com", is_active=True)
+    user = User(
+        id=uuid4(),
+        email="invitee@example.com",
+        is_active=True,
+        auth_provider="local",
+    )
+    db_session.add_all([org_a, org_b, invited_org, inviter, user])
+    db_session.flush()
+    db_session.add_all(
+        [
+            OrganizationMember(organization_id=org_a.id, user_id=user.id, role=RoleEnum.ADMIN.value),
+            OrganizationMember(organization_id=org_b.id, user_id=user.id, role=RoleEnum.READER.value),
+        ]
+    )
+    db_session.flush()
+    cred_a = provision_membership_credential(
+        db_session, user_id=user.id, organization_id=org_a.id, user=user
+    )
+    cred_b = provision_membership_credential(
+        db_session, user_id=user.id, organization_id=org_b.id, user=user
+    )
+    set_org_password_hash(cred_a, hash_password(password_a))
+    set_org_password_hash(cred_b, hash_password(password_b))
+    provision_default_workspace(
+        db_session,
+        organization_id=invited_org.id,
+        created_by_user_id=inviter.id,
+    )
+    invitation = Invitation(
+        organization_id=invited_org.id,
+        invited_by_id=inviter.id,
+        email=user.email,
+        role=RoleEnum.WRITER.value,
+        status=InvitationStatus.PENDING.value,
+        token="invite-source-org",
+        expires_at=datetime.now(timezone.utc) + timedelta(days=7),
+    )
+    db_session.add(invitation)
+    db_session.commit()
+
+    accept_invitation(
+        db_session,
+        invitation,
+        user,
+        source_organization_id=org_b.id,
+    )
+
+    invited_cred = get_credential(
+        db_session, user_id=user.id, organization_id=invited_org.id
+    )
+    assert invited_cred is not None
+    assert invited_cred.password_hash == cred_b.password_hash
+    assert invited_cred.password_hash != cred_a.password_hash
+    assert verify_password(password_b, invited_cred.password_hash)
+    assert not verify_password(password_a, invited_cred.password_hash)
+
+    matched_b = match_password_memberships(db_session, user=user, password=password_b)
+    assert {org.id for _, org in matched_b} == {org_b.id, invited_org.id}
+    matched_a = match_password_memberships(db_session, user=user, password=password_a)
+    assert {org.id for _, org in matched_a} == {org_a.id}
+
+
+def test_accept_invitation_skips_inheritance_when_org_passwords_differ(db_session):
+    from datetime import datetime, timedelta, timezone
+
+    from app.core.auth.org_credentials import (
+        get_credential,
+        provision_membership_credential,
+        set_org_password_hash,
+    )
+    from app.models.database import Invitation, InvitationStatus
+    from app.services.invitation_service import accept_invitation
+    from app.services.organization_provisioning import provision_default_workspace
+
+    org_a = Organization(id=uuid4(), name="Org A")
+    org_b = Organization(id=uuid4(), name="Org B")
+    invited_org = Organization(id=uuid4(), name="Invited Org")
+    inviter = User(id=uuid4(), email="inviter@example.com", is_active=True)
+    user = User(
+        id=uuid4(),
+        email="invitee@example.com",
+        is_active=True,
+        auth_provider="local",
+    )
+    db_session.add_all([org_a, org_b, invited_org, inviter, user])
+    db_session.flush()
+    db_session.add_all(
+        [
+            OrganizationMember(organization_id=org_a.id, user_id=user.id, role=RoleEnum.ADMIN.value),
+            OrganizationMember(organization_id=org_b.id, user_id=user.id, role=RoleEnum.READER.value),
+        ]
+    )
+    db_session.flush()
+    cred_a = provision_membership_credential(
+        db_session, user_id=user.id, organization_id=org_a.id, user=user
+    )
+    cred_b = provision_membership_credential(
+        db_session, user_id=user.id, organization_id=org_b.id, user=user
+    )
+    set_org_password_hash(cred_a, hash_password("OrgAPass1!"))
+    set_org_password_hash(cred_b, hash_password("OrgBPass1!"))
+    provision_default_workspace(
+        db_session,
+        organization_id=invited_org.id,
+        created_by_user_id=inviter.id,
+    )
+    invitation = Invitation(
+        organization_id=invited_org.id,
+        invited_by_id=inviter.id,
+        email=user.email,
+        role=RoleEnum.WRITER.value,
+        status=InvitationStatus.PENDING.value,
+        token="invite-no-inherit",
+        expires_at=datetime.now(timezone.utc) + timedelta(days=7),
+    )
+    db_session.add(invitation)
+    db_session.commit()
+
+    accept_invitation(db_session, invitation, user)
+
+    invited_cred = get_credential(
+        db_session, user_id=user.id, organization_id=invited_org.id
+    )
+    assert invited_cred is not None
+    assert invited_cred.password_hash is None

--- a/tests/test_api/test_org_credentials.py
+++ b/tests/test_api/test_org_credentials.py
@@ -100,6 +100,13 @@ def test_admin_reset_password_only_invalidates_target_org_session(
             role=RoleEnum.ADMIN.value,
         )
     )
+    db_session.flush()
+    from app.core.auth.org_credentials import provision_membership_credential, set_org_password_hash
+
+    admin_cred = provision_membership_credential(
+        db_session, user_id=admin.id, organization_id=org_a_id
+    )
+    set_org_password_hash(admin_cred, hash_password("AdminPass1!"))
     db_session.commit()
 
     login_admin = client.post(
@@ -168,6 +175,70 @@ def test_login_only_unlocks_orgs_with_matching_password(
         json={"email": user.email, "password": "SharedPass1!", "organization_id": str(org_b.id)},
     )
     assert login_b.status_code == 401
+
+
+def test_password_change_does_not_unlock_other_org(
+    client, db_session, org_id, seed_org, enable_local_password
+):
+    org_b = Organization(id=uuid4(), name="Org B")
+    user = User(
+        id=uuid4(),
+        email="leak-check@example.com",
+        password_hash=hash_password("SharedPass1!"),
+        is_active=True,
+        auth_provider="local",
+    )
+    db_session.add_all([org_b, user])
+    db_session.flush()
+    db_session.add_all(
+        [
+            OrganizationMember(organization_id=org_id, user_id=user.id, role=RoleEnum.ADMIN.value),
+            OrganizationMember(organization_id=org_b.id, user_id=user.id, role=RoleEnum.READER.value),
+        ]
+    )
+    db_session.flush()
+    cred_a = get_or_create_credential(
+        db_session, user_id=user.id, organization_id=org_id, user=user
+    )
+    cred_b = get_or_create_credential(
+        db_session, user_id=user.id, organization_id=org_b.id, user=user
+    )
+    cred_a.password_hash = user.password_hash
+    cred_b.password_hash = hash_password("Different2!")
+    db_session.commit()
+
+    login_a = client.post(
+        "/api/v1/auth/login",
+        json={"email": user.email, "password": "SharedPass1!", "organization_id": str(org_id)},
+    )
+    assert login_a.status_code == 200
+    token_a = login_a.json()["access_token"]
+
+    change = client.post(
+        "/api/v1/auth/password",
+        headers={"Authorization": f"Bearer {token_a}"},
+        json={"current_password": "SharedPass1!", "new_password": "ChangedA1!"},
+    )
+    assert change.status_code == 200
+
+    db_session.refresh(user)
+    db_session.refresh(cred_a)
+    db_session.refresh(cred_b)
+    assert verify_password("ChangedA1!", cred_a.password_hash)
+    assert verify_password("Different2!", cred_b.password_hash)
+    assert user.password_hash and verify_password("SharedPass1!", user.password_hash)
+
+    login_b_new = client.post(
+        "/api/v1/auth/login",
+        json={"email": user.email, "password": "ChangedA1!", "organization_id": str(org_b.id)},
+    )
+    assert login_b_new.status_code == 401
+
+    login_b_old = client.post(
+        "/api/v1/auth/login",
+        json={"email": user.email, "password": "Different2!", "organization_id": str(org_b.id)},
+    )
+    assert login_b_old.status_code == 200
 
 
 def test_password_change_invalidates_only_current_org_session(

--- a/tests/test_api/test_platform_admin.py
+++ b/tests/test_api/test_platform_admin.py
@@ -61,6 +61,27 @@ def test_platform_login_returns_token(client, platform_admin_user):
     assert body["admin"]["email"] == "platform@example.com"
 
 
+def test_platform_login_sets_http_only_cookie_when_enabled(
+    client, platform_admin_user, monkeypatch
+):
+    from app.core.auth.cookies import COOKIE_CSRF, COOKIE_PLATFORM_ACCESS
+
+    monkeypatch.setattr(settings, "AUTH_COOKIE_SESSION_ENABLED", True)
+    response = client.post(
+        "/api/v1/platform/auth/login",
+        json={"email": "platform@example.com", "password": PLATFORM_PASSWORD},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["access_token"] == ""
+    assert COOKIE_PLATFORM_ACCESS in response.cookies
+    assert COOKIE_CSRF in response.cookies
+
+    me = client.get("/api/v1/platform/auth/me")
+    assert me.status_code == 200
+    assert me.json()["email"] == "platform@example.com"
+
+
 def test_platform_login_returns_404_when_no_admins(client, db_session):
     db_session.query(PlatformAdmin).delete()
     db_session.commit()

--- a/tests/test_api/test_playground_routes.py
+++ b/tests/test_api/test_playground_routes.py
@@ -1,5 +1,9 @@
 """API tests for playground routes."""
 
+from uuid import uuid4
+
+from app.models.database import CallRecordingSource, Integration, IntegrationPlatform
+
 
 def test_extract_transcript_from_smallest_call_data():
     from app.api.v1.routes.playground import extract_transcript_from_call_data
@@ -27,3 +31,67 @@ def test_list_playground_call_recordings(authenticated_client, make_call_recordi
     assert response.status_code == 200
     assert len(response.json()) == 1
     assert response.json()[0]["call_short_id"] == "111111"
+
+
+def test_refresh_call_recording_accepts_inline_provider_call_id(
+    authenticated_client,
+    make_call_recording,
+    make_agent,
+    db_session,
+    org_id,
+    monkeypatch,
+):
+    from app.api.v1.routes import playground as playground_routes
+
+    integration = Integration(
+        id=uuid4(),
+        organization_id=org_id,
+        platform=IntegrationPlatform.VAPI.value,
+        api_key="encrypted-key",
+        name="Vapi",
+        is_active=True,
+    )
+    db_session.add(integration)
+    db_session.flush()
+    agent = make_agent(
+        voice_ai_integration_id=integration.id,
+        voice_ai_agent_id="assistant-1",
+        call_medium="web_call",
+    )
+    make_call_recording(
+        call_short_id="654321",
+        source=CallRecordingSource.PLAYGROUND.value,
+        provider_platform=IntegrationPlatform.VAPI.value,
+        provider_call_id=None,
+        agent_id=agent.id,
+    )
+
+    monkeypatch.setattr(playground_routes, "decrypt_api_key", lambda _key: "plain-key")
+    monkeypatch.setattr(playground_routes, "poll_call_metrics", lambda *_args, **_kwargs: None)
+
+    response = authenticated_client.post(
+        "/api/v1/playground/call-recordings/654321/refresh",
+        json={"provider_call_id": "vapi-call-abc"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["message"] == "Call recording refresh initiated"
+
+
+def test_refresh_call_recording_without_provider_info_returns_400(
+    authenticated_client,
+    make_call_recording,
+):
+    make_call_recording(
+        call_short_id="000001",
+        source=CallRecordingSource.PLAYGROUND.value,
+        provider_platform=None,
+        provider_call_id=None,
+    )
+
+    response = authenticated_client.post(
+        "/api/v1/playground/call-recordings/000001/refresh",
+    )
+
+    assert response.status_code == 400
+    assert "provider" in response.json()["detail"].lower()

--- a/tests/test_api/test_playground_routes.py
+++ b/tests/test_api/test_playground_routes.py
@@ -1,5 +1,6 @@
 """API tests for playground routes."""
 
+from unittest.mock import MagicMock
 from uuid import uuid4
 
 from app.models.database import CallRecordingSource, Integration, IntegrationPlatform
@@ -31,6 +32,33 @@ def test_list_playground_call_recordings(authenticated_client, make_call_recordi
     assert response.status_code == 200
     assert len(response.json()) == 1
     assert response.json()[0]["call_short_id"] == "111111"
+
+
+def test_validate_provider_call_id_instantiates_voice_provider(monkeypatch):
+    from app.api.v1.routes import playground as playground_routes
+
+    mock_provider = MagicMock()
+    mock_provider.retrieve_call_metrics.return_value = {"assistantId": "assistant-1"}
+    mock_class = MagicMock(return_value=mock_provider)
+    monkeypatch.setattr(playground_routes, "get_voice_provider", lambda _platform: mock_class)
+
+    recording = MagicMock()
+    recording.provider_call_id = None
+    recording.call_data = {}
+    recording.provider_platform = "vapi"
+
+    agent = MagicMock()
+    agent.voice_ai_agent_id = "assistant-1"
+
+    playground_routes._validate_provider_call_id_for_recording(
+        recording,
+        "vapi-call-abc",
+        agent,
+        "plain-key",
+    )
+
+    mock_class.assert_called_once_with(api_key="plain-key")
+    mock_provider.retrieve_call_metrics.assert_called_once_with("vapi-call-abc")
 
 
 def test_refresh_call_recording_accepts_inline_provider_call_id(

--- a/tests/test_api/test_playground_routes.py
+++ b/tests/test_api/test_playground_routes.py
@@ -68,6 +68,11 @@ def test_refresh_call_recording_accepts_inline_provider_call_id(
 
     monkeypatch.setattr(playground_routes, "decrypt_api_key", lambda _key: "plain-key")
     monkeypatch.setattr(playground_routes, "poll_call_metrics", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        playground_routes,
+        "_validate_provider_call_id_for_recording",
+        lambda *_args, **_kwargs: None,
+    )
 
     response = authenticated_client.post(
         "/api/v1/playground/call-recordings/654321/refresh",
@@ -76,6 +81,46 @@ def test_refresh_call_recording_accepts_inline_provider_call_id(
 
     assert response.status_code == 200
     assert response.json()["message"] == "Call recording refresh initiated"
+
+
+def test_refresh_rejects_mismatched_provider_call_id(
+    authenticated_client,
+    make_call_recording,
+    make_agent,
+    db_session,
+    org_id,
+):
+    integration = Integration(
+        id=uuid4(),
+        organization_id=org_id,
+        platform=IntegrationPlatform.RETELL.value,
+        api_key="encrypted-key",
+        name="Retell",
+        is_active=True,
+    )
+    db_session.add(integration)
+    db_session.flush()
+    agent = make_agent(
+        voice_ai_integration_id=integration.id,
+        voice_ai_agent_id="agent-retell-1",
+        call_medium="web_call",
+    )
+    make_call_recording(
+        call_short_id="222333",
+        source=CallRecordingSource.PLAYGROUND.value,
+        provider_platform=IntegrationPlatform.RETELL.value,
+        provider_call_id=None,
+        agent_id=agent.id,
+        call_data={"call_id": "retell-bound-call"},
+    )
+
+    response = authenticated_client.post(
+        "/api/v1/playground/call-recordings/222333/refresh",
+        json={"provider_call_id": "foreign-call-id"},
+    )
+
+    assert response.status_code == 400
+    assert "does not match" in response.json()["detail"].lower()
 
 
 def test_refresh_call_recording_without_provider_info_returns_400(

--- a/tests/test_api/test_security_rbac.py
+++ b/tests/test_api/test_security_rbac.py
@@ -1,0 +1,92 @@
+"""Security tests for reader RBAC middleware with query-token auth."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api.v1.routes import personas
+from app.config import settings
+from app.core.auth.tokens import create_access_token
+from app.core.password import hash_password
+from app.core.rbac_middleware import ReaderReadOnlyMiddleware
+from app.database import get_db
+from app.dependencies import get_organization_id, get_workspace_id
+from app.models.database import OrganizationMember, RoleEnum, User
+from app.services.workspace_rbac import add_workspace_member, seed_system_workspace_roles
+
+
+@pytest.fixture
+def enable_local_password(monkeypatch):
+    monkeypatch.setattr(settings, "AUTH_PROVIDERS", ["api_key", "local_password"])
+    monkeypatch.setattr(settings, "AUTH_LOCAL_ALLOW_SIGNUP", True)
+    monkeypatch.setattr(settings, "AUTH_GATED_SIGNUP_ENABLED", False)
+    from app.core.auth.providers import reset_provider_registry
+
+    reset_provider_registry()
+    return settings
+
+
+def test_reader_blocked_when_auth_via_query_access_token_only(
+    db_session,
+    org_id,
+    seed_org,
+    enable_local_password,
+    default_workspace,
+    monkeypatch,
+):
+    user = User(
+        id=uuid4(),
+        email="reader@example.com",
+        password_hash=hash_password("ReaderPass1!"),
+        is_active=True,
+        session_epoch=1,
+    )
+    db_session.add(user)
+    db_session.add(
+        OrganizationMember(
+            organization_id=org_id,
+            user_id=user.id,
+            role=RoleEnum.READER.value,
+        )
+    )
+    roles = seed_system_workspace_roles(db_session, organization_id=org_id)
+    add_workspace_member(
+        db_session,
+        workspace_id=default_workspace.id,
+        user_id=user.id,
+        role_id=roles["Editor"].id,
+    )
+    db_session.commit()
+
+    token, _, _ = create_access_token(
+        user_id=user.id,
+        organization_id=org_id,
+        email=user.email,
+        session_epoch=user.session_epoch,
+    )
+
+    def _override_db():
+        yield db_session
+
+    monkeypatch.setattr("app.core.rbac_middleware.get_db", _override_db)
+
+    app = FastAPI()
+    app.add_middleware(ReaderReadOnlyMiddleware)
+    app.include_router(personas.router, prefix="/api/v1")
+    app.dependency_overrides[get_db] = _override_db
+    app.dependency_overrides[get_organization_id] = lambda: org_id
+    app.dependency_overrides[get_workspace_id] = lambda: default_workspace.id
+
+    with TestClient(app) as client:
+        response = client.post(
+            f"/api/v1/personas?access_token={token}",
+            json={"name": "Blocked Persona", "gender": "neutral", "is_custom": False},
+            headers={"X-Workspace-Id": str(default_workspace.id)},
+        )
+
+    assert response.status_code == 403
+    assert "reader" in response.json()["detail"].lower()

--- a/tests/test_api/test_voice_agent_routes.py
+++ b/tests/test_api/test_voice_agent_routes.py
@@ -98,6 +98,61 @@ def test_voice_agent_connect_accepts_bearer_access_token(
     assert "X-API-Key=" not in ws_url
 
 
+def test_voice_agent_connect_accepts_eai_access_cookie(
+    client, db_session, monkeypatch
+):
+    from app.core.auth.cookies import COOKIE_ACCESS
+
+    monkeypatch.setattr(settings, "AUTH_COOKIE_SESSION_ENABLED", True)
+    monkeypatch.setattr(settings, "AUTH_PROVIDERS", ["api_key", "local_password"])
+
+    org = Organization(id=uuid4(), name="Cookie Org")
+    user = User(
+        id=uuid4(),
+        email="cookie-voice@example.com",
+        password_hash=hash_password("the-password"),
+        is_active=True,
+        auth_provider="local",
+    )
+    db_session.add_all([org, user])
+    db_session.flush()
+    db_session.add(
+        OrganizationMember(
+            organization_id=org.id,
+            user_id=user.id,
+            role=RoleEnum.ADMIN.value,
+        )
+    )
+    from app.models.database import AIProvider, ModelProvider
+
+    db_session.add(
+        AIProvider(
+            id=uuid4(),
+            organization_id=org.id,
+            provider=ModelProvider.GOOGLE.value,
+            api_key="enc-google-key",
+            name="Google Key",
+            is_active=True,
+        )
+    )
+    db_session.commit()
+
+    login_response = client.post(
+        "/api/v1/auth/login",
+        json={"email": "cookie-voice@example.com", "password": "the-password"},
+    )
+    assert login_response.status_code == 200
+    access_token = login_response.cookies.get(COOKIE_ACCESS)
+    assert access_token
+
+    response = client.get("/api/v1/voice-agent/connect")
+
+    assert response.status_code == 200, response.text
+    ws_url = response.json()["ws_url"]
+    assert "/api/v1/voice-agent/ws" in ws_url
+    assert f"token={access_token}" in ws_url
+
+
 def test_voice_agent_audio_lists_files(authenticated_client, monkeypatch):
     from app.api.v1.routes import voice_agent as voice_agent_routes
 

--- a/tests/test_api/test_voice_agent_routes.py
+++ b/tests/test_api/test_voice_agent_routes.py
@@ -150,7 +150,8 @@ def test_voice_agent_connect_accepts_eai_access_cookie(
     assert response.status_code == 200, response.text
     ws_url = response.json()["ws_url"]
     assert "/api/v1/voice-agent/ws" in ws_url
-    assert f"token={access_token}" in ws_url
+    assert "token=" not in ws_url
+    assert "X-API-Key=" not in ws_url
 
 
 def test_voice_agent_audio_lists_files(authenticated_client, monkeypatch):

--- a/tests/test_api/test_voice_agent_routes.py
+++ b/tests/test_api/test_voice_agent_routes.py
@@ -154,6 +154,68 @@ def test_voice_agent_connect_accepts_eai_access_cookie(
     assert "X-API-Key=" not in ws_url
 
 
+def test_voice_agent_connect_cookie_cross_host_returns_handshake_token(
+    client, db_session, monkeypatch
+):
+    from urllib.parse import parse_qs, urlparse
+
+    from app.core.auth.cookies import COOKIE_ACCESS
+
+    monkeypatch.setattr(settings, "AUTH_COOKIE_SESSION_ENABLED", True)
+    monkeypatch.setattr(settings, "AUTH_PROVIDERS", ["api_key", "local_password"])
+    monkeypatch.setattr(settings, "MEDIA_WS_BASE_URL", "wss://media.example.com")
+
+    org = Organization(id=uuid4(), name="Cross Host Org")
+    user = User(
+        id=uuid4(),
+        email="cross-host@example.com",
+        password_hash=hash_password("the-password"),
+        is_active=True,
+        auth_provider="local",
+    )
+    db_session.add_all([org, user])
+    db_session.flush()
+    db_session.add(
+        OrganizationMember(
+            organization_id=org.id,
+            user_id=user.id,
+            role=RoleEnum.ADMIN.value,
+        )
+    )
+    from app.models.database import AIProvider, ModelProvider
+
+    db_session.add(
+        AIProvider(
+            id=uuid4(),
+            organization_id=org.id,
+            provider=ModelProvider.GOOGLE.value,
+            api_key="enc-google-key",
+            name="Google Key",
+            is_active=True,
+        )
+    )
+    db_session.commit()
+
+    login_response = client.post(
+        "/api/v1/auth/login",
+        json={"email": "cross-host@example.com", "password": "the-password"},
+    )
+    assert login_response.status_code == 200
+    session_cookie = login_response.cookies.get(COOKIE_ACCESS)
+    assert session_cookie
+
+    response = client.get(
+        "/api/v1/voice-agent/connect",
+        headers={"Host": "api.example.com"},
+    )
+    assert response.status_code == 200, response.text
+    ws_url = response.json()["ws_url"]
+    assert ws_url.startswith("wss://media.example.com")
+    query_token = parse_qs(urlparse(ws_url).query).get("token", [None])[0]
+    assert query_token
+    assert query_token != session_cookie
+
+
 def test_voice_agent_audio_lists_files(authenticated_client, monkeypatch):
     from app.api.v1.routes import voice_agent as voice_agent_routes
 

--- a/tests/test_core/test_auth_cookies.py
+++ b/tests/test_core/test_auth_cookies.py
@@ -101,6 +101,21 @@ def test_refresh_rotates_http_only_session_cookies(cookie_auth_client):
     assert me.json()["email"] == "cookie@example.com"
 
 
+def test_event_stream_token_returns_cookie_session_access_token(cookie_auth_client):
+    client, _user = cookie_auth_client
+    login = client.post(
+        "/api/v1/auth/login",
+        json={"email": "cookie@example.com", "password": "CookiePass1!"},
+    )
+    assert login.status_code == 200
+    cookie_token = login.cookies.get(COOKIE_ACCESS)
+    assert cookie_token
+
+    response = client.get("/api/v1/auth/event-stream-token")
+    assert response.status_code == 200
+    assert response.json()["token"] == cookie_token
+
+
 def test_csrf_required_for_cookie_authenticated_mutations(cookie_auth_client):
     client, _user = cookie_auth_client
     login = client.post(

--- a/tests/test_core/test_auth_cookies.py
+++ b/tests/test_core/test_auth_cookies.py
@@ -1,0 +1,94 @@
+"""Tests for httpOnly cookie sessions and CSRF middleware."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.config import settings
+from app.core.auth.cookies import COOKIE_ACCESS, COOKIE_CSRF, COOKIE_REFRESH, CSRF_HEADER
+from app.core.csrf_middleware import CsrfMiddleware
+from app.core.password import hash_password
+from app.models.database import Organization, OrganizationMember, RoleEnum, User
+
+
+@pytest.fixture
+def cookie_auth_client(db_session, org_id, monkeypatch):
+    monkeypatch.setattr(settings, "AUTH_COOKIE_SESSION_ENABLED", True)
+    monkeypatch.setattr(settings, "AUTH_PROVIDERS", ["api_key", "local_password"])
+    monkeypatch.setattr(settings, "AUTH_LOCAL_ALLOW_SIGNUP", True)
+    from app.core.auth.providers import reset_provider_registry
+
+    reset_provider_registry()
+
+    org = Organization(id=org_id, name="Cookie Test Org")
+    user = User(
+        id=uuid4(),
+        email="cookie@example.com",
+        password_hash=hash_password("CookiePass1!"),
+        is_active=True,
+        session_epoch=0,
+    )
+    db_session.add(org)
+    db_session.add(user)
+    db_session.add(
+        OrganizationMember(
+            organization_id=org_id,
+            user_id=user.id,
+            role=RoleEnum.ADMIN.value,
+        )
+    )
+    db_session.commit()
+
+    from app.api.v1.routes import auth
+    from app.database import get_db
+
+    app = FastAPI()
+    app.add_middleware(CsrfMiddleware)
+    app.include_router(auth.router, prefix="/api/v1")
+
+    def _override_db():
+        yield db_session
+
+    app.dependency_overrides[get_db] = _override_db
+
+    with TestClient(app) as client:
+        yield client, user
+
+
+def test_login_sets_http_only_session_cookies(cookie_auth_client):
+    client, _user = cookie_auth_client
+    response = client.post(
+        "/api/v1/auth/login",
+        json={"email": "cookie@example.com", "password": "CookiePass1!"},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["access_token"] == ""
+    assert body["refresh_token"] is None
+    assert COOKIE_ACCESS in response.cookies
+    assert COOKIE_REFRESH in response.cookies
+    assert COOKIE_CSRF in response.cookies
+
+
+def test_csrf_required_for_cookie_authenticated_mutations(cookie_auth_client):
+    client, _user = cookie_auth_client
+    login = client.post(
+        "/api/v1/auth/login",
+        json={"email": "cookie@example.com", "password": "CookiePass1!"},
+    )
+    assert login.status_code == 200
+    csrf = login.cookies.get(COOKIE_CSRF)
+    assert csrf
+
+    blocked = client.post("/api/v1/auth/logout")
+    assert blocked.status_code == 403
+
+    allowed = client.post(
+        "/api/v1/auth/logout",
+        headers={CSRF_HEADER: csrf},
+    )
+    assert allowed.status_code == 200

--- a/tests/test_core/test_auth_cookies.py
+++ b/tests/test_core/test_auth_cookies.py
@@ -101,21 +101,6 @@ def test_refresh_rotates_http_only_session_cookies(cookie_auth_client):
     assert me.json()["email"] == "cookie@example.com"
 
 
-def test_event_stream_token_returns_cookie_session_access_token(cookie_auth_client):
-    client, _user = cookie_auth_client
-    login = client.post(
-        "/api/v1/auth/login",
-        json={"email": "cookie@example.com", "password": "CookiePass1!"},
-    )
-    assert login.status_code == 200
-    cookie_token = login.cookies.get(COOKIE_ACCESS)
-    assert cookie_token
-
-    response = client.get("/api/v1/auth/event-stream-token")
-    assert response.status_code == 200
-    assert response.json()["token"] == cookie_token
-
-
 def test_csrf_required_for_cookie_authenticated_mutations(cookie_auth_client):
     client, _user = cookie_auth_client
     login = client.post(
@@ -127,6 +112,29 @@ def test_csrf_required_for_cookie_authenticated_mutations(cookie_auth_client):
     assert csrf
 
     blocked = client.post("/api/v1/auth/logout")
+    assert blocked.status_code == 403
+
+    allowed = client.post(
+        "/api/v1/auth/logout",
+        headers={CSRF_HEADER: csrf},
+    )
+    assert allowed.status_code == 200
+
+
+def test_csrf_not_bypassed_by_stale_api_key_header(cookie_auth_client):
+    client, _user = cookie_auth_client
+    login = client.post(
+        "/api/v1/auth/login",
+        json={"email": "cookie@example.com", "password": "CookiePass1!"},
+    )
+    assert login.status_code == 200
+    csrf = login.cookies.get(COOKIE_CSRF)
+    assert csrf
+
+    blocked = client.post(
+        "/api/v1/auth/logout",
+        headers={"X-API-Key": "stale-localstorage-key"},
+    )
     assert blocked.status_code == 403
 
     allowed = client.post(

--- a/tests/test_core/test_auth_cookies.py
+++ b/tests/test_core/test_auth_cookies.py
@@ -74,6 +74,33 @@ def test_login_sets_http_only_session_cookies(cookie_auth_client):
     assert COOKIE_CSRF in response.cookies
 
 
+def test_refresh_rotates_http_only_session_cookies(cookie_auth_client):
+    client, _user = cookie_auth_client
+    login = client.post(
+        "/api/v1/auth/login",
+        json={"email": "cookie@example.com", "password": "CookiePass1!"},
+    )
+    assert login.status_code == 200
+    original_access = login.cookies.get(COOKIE_ACCESS)
+    original_refresh = login.cookies.get(COOKIE_REFRESH)
+    assert original_access
+    assert original_refresh
+
+    refreshed = client.post("/api/v1/auth/refresh")
+    assert refreshed.status_code == 200
+    body = refreshed.json()
+    assert body["access_token"] == ""
+    assert body["refresh_token"] is None
+    assert refreshed.cookies.get(COOKIE_ACCESS)
+    assert refreshed.cookies.get(COOKIE_REFRESH)
+    assert refreshed.cookies.get(COOKIE_ACCESS) != original_access
+    assert refreshed.cookies.get(COOKIE_REFRESH) != original_refresh
+
+    me = client.get("/api/v1/auth/me")
+    assert me.status_code == 200
+    assert me.json()["email"] == "cookie@example.com"
+
+
 def test_csrf_required_for_cookie_authenticated_mutations(cookie_auth_client):
     client, _user = cookie_auth_client
     login = client.post(

--- a/tests/test_core/test_auth_dependency.py
+++ b/tests/test_core/test_auth_dependency.py
@@ -5,7 +5,7 @@ from uuid import uuid4
 
 from app.config import settings
 from app.core.auth.cookies import COOKIE_ACCESS
-from app.core.auth.dependency import _resolve
+from app.core.auth.dependency import _resolve, resolve_websocket_credentials
 from app.core.auth.providers import reset_provider_registry
 from app.core.auth.tokens import create_access_token, decode_access_token
 from app.models.database import Organization, OrganizationMember, RoleEnum, User
@@ -98,3 +98,23 @@ def test_resolve_accepts_eai_access_cookie(db_session, org_id, monkeypatch):
 
     assert principal is not None
     assert str(principal.user_id) == str(user_id)
+
+
+def test_resolve_websocket_credentials_reads_eai_access_cookie(db_session, org_id, monkeypatch):
+    monkeypatch.setattr(settings, "AUTH_PROVIDERS", ["api_key", "local_password"])
+    reset_provider_registry()
+    user_id = uuid4()
+    access_token, _, _ = create_access_token(
+        user_id=user_id,
+        organization_id=org_id,
+        email="ws-cookie@example.com",
+    )
+
+    websocket = MagicMock()
+    websocket.query_params = {}
+    websocket.cookies = {COOKIE_ACCESS: access_token}
+    websocket.scope = {"query_string": b""}
+
+    cred = resolve_websocket_credentials(websocket)
+    assert cred.bearer_token == access_token
+    assert cred.api_key is None

--- a/tests/test_core/test_auth_dependency.py
+++ b/tests/test_core/test_auth_dependency.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 from uuid import uuid4
 
 from app.config import settings
+from app.core.auth.cookies import COOKIE_ACCESS
 from app.core.auth.dependency import _resolve
 from app.core.auth.providers import reset_provider_registry
 from app.core.auth.tokens import create_access_token, decode_access_token
@@ -58,3 +59,42 @@ def test_resolve_prefers_query_token_over_stale_access_token_cookie(
     claims = decode_access_token(fresh_token)
     assert str(principal.user_id) == claims["sub"]
     assert principal.email == "fresh@example.com"
+
+
+def test_resolve_accepts_eai_access_cookie(db_session, org_id, monkeypatch):
+    monkeypatch.setattr(settings, "AUTH_PROVIDERS", ["api_key", "local_password"])
+    reset_provider_registry()
+    user_id = uuid4()
+    db_session.add(Organization(id=org_id, name="Cookie Auth Dep Org"))
+    db_session.add(
+        User(
+            id=user_id,
+            email="cookie-dep@example.com",
+            name="Cookie User",
+            is_active=True,
+        )
+    )
+    db_session.add(
+        OrganizationMember(
+            organization_id=org_id,
+            user_id=user_id,
+            role=RoleEnum.ADMIN.value,
+        )
+    )
+    db_session.commit()
+
+    access_token, _, _ = create_access_token(
+        user_id=user_id,
+        organization_id=org_id,
+        email="cookie-dep@example.com",
+    )
+
+    request = MagicMock()
+    request.headers = {}
+    request.cookies = {COOKIE_ACCESS: access_token}
+    request.query_params = {}
+
+    principal = _resolve(None, None, None, db_session, request=request)
+
+    assert principal is not None
+    assert str(principal.user_id) == str(user_id)

--- a/tests/test_core/test_auth_dependency.py
+++ b/tests/test_core/test_auth_dependency.py
@@ -5,7 +5,11 @@ from uuid import uuid4
 
 from app.config import settings
 from app.core.auth.cookies import COOKIE_ACCESS
-from app.core.auth.dependency import _resolve, resolve_websocket_credentials
+from app.core.auth.dependency import (
+    _resolve,
+    resolve_request_credentials_with_sources,
+    resolve_websocket_credentials,
+)
 from app.core.auth.providers import reset_provider_registry
 from app.core.auth.tokens import create_access_token, decode_access_token
 from app.models.database import Organization, OrganizationMember, RoleEnum, User
@@ -118,3 +122,30 @@ def test_resolve_websocket_credentials_reads_eai_access_cookie(db_session, org_i
     cred = resolve_websocket_credentials(websocket)
     assert cred.bearer_token == access_token
     assert cred.api_key is None
+
+
+def test_resolve_credentials_with_sources_prefers_header_over_cookie():
+    request = MagicMock()
+    request.headers = {}
+    request.cookies = {COOKIE_ACCESS: "cookie-token"}
+    request.query_params = {}
+
+    resolved = resolve_request_credentials_with_sources(
+        authorization="Bearer header-token",
+        request=request,
+    )
+
+    assert resolved.credential.bearer_token == "header-token"
+    assert resolved.bearer_source == "header"
+
+
+def test_resolve_credentials_with_sources_marks_cookie_bearer():
+    request = MagicMock()
+    request.headers = {}
+    request.cookies = {COOKIE_ACCESS: "cookie-token"}
+    request.query_params = {}
+
+    resolved = resolve_request_credentials_with_sources(request=request)
+
+    assert resolved.credential.bearer_token == "cookie-token"
+    assert resolved.bearer_source == "cookie"

--- a/tests/test_core/test_health_security.py
+++ b/tests/test_core/test_health_security.py
@@ -1,0 +1,102 @@
+"""Tests for /health abuse protection and information disclosure boundaries."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from app.config import settings
+from app.core.api_rate_limit import check_health_rate_limit
+from app.core.health import build_liveness_status, build_readiness_status
+from app.core.migration_middleware import MigrationCheckMiddleware
+from app.core.operational_access_middleware import OperationalAccessMiddleware
+
+
+@pytest.fixture
+def health_app(monkeypatch):
+    monkeypatch.setattr(settings, "OPERATIONAL_PUBLIC", False)
+    monkeypatch.setattr(settings, "OPERATIONAL_TRUSTED_IPS", ["10.0.0.0/8"])
+    monkeypatch.setattr(settings, "API_RATE_LIMIT_ENFORCE", True)
+    monkeypatch.setattr(settings, "HEALTH_RATE_LIMIT_PER_MINUTE", 3)
+    monkeypatch.setattr(settings, "HEALTH_READINESS_CACHE_SECONDS", 0)
+
+    def _is_trusted_probe(request: Request) -> bool:
+        return request.headers.get("x-test-trusted-probe") == "1"
+
+    monkeypatch.setattr(
+        "app.core.operational_access_middleware.is_operational_access_allowed",
+        _is_trusted_probe,
+    )
+
+    app = FastAPI()
+    app.add_middleware(MigrationCheckMiddleware)
+    app.add_middleware(OperationalAccessMiddleware)
+
+    @app.get("/health")
+    def health(request: Request):
+        from app.core.operational_access_middleware import is_operational_access_allowed
+
+        check_health_rate_limit(request)
+        if is_operational_access_allowed(request):
+            payload, status_code = build_readiness_status(detailed=False)
+        else:
+            payload, status_code = build_liveness_status()
+        return JSONResponse(content=payload, status_code=status_code)
+
+    with TestClient(app) as client:
+        yield client
+
+
+def test_public_health_is_liveness_only_when_migrations_pending(monkeypatch, health_app):
+    monkeypatch.setattr(
+        "app.core.health.check_migrations_status",
+        lambda: (False, ["099_pending.sql"]),
+    )
+
+    response = health_app.get("/health", headers={"X-Forwarded-For": "203.0.113.1"})
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_trusted_lb_peer_gets_readiness_when_migrations_pending(monkeypatch, health_app):
+    monkeypatch.setattr(
+        "app.core.health.check_migrations_status",
+        lambda: (False, ["099_pending.sql"]),
+    )
+
+    response = health_app.get("/health", headers={"x-test-trusted-probe": "1"})
+
+    assert response.status_code == 503
+    assert response.json() == {"status": "degraded"}
+
+
+def test_public_health_rate_limited(monkeypatch, health_app):
+    monkeypatch.setattr(
+        "app.core.health.check_migrations_status",
+        lambda: (True, []),
+    )
+
+    headers = {"X-Forwarded-For": "198.51.100.9"}
+    counts = iter([1, 2, 3, 4])
+    with patch("app.core.api_rate_limit._sliding_window_count", side_effect=lambda *a, **k: next(counts)):
+        for _ in range(3):
+            assert health_app.get("/health", headers=headers).status_code == 200
+
+        blocked = health_app.get("/health", headers=headers)
+        assert blocked.status_code == 429
+
+
+def test_trusted_lb_peer_not_rate_limited(monkeypatch, health_app):
+    monkeypatch.setattr(
+        "app.core.health.check_migrations_status",
+        lambda: (True, []),
+    )
+
+    headers = {"x-test-trusted-probe": "1"}
+    for _ in range(6):
+        assert health_app.get("/health", headers=headers).status_code == 200

--- a/tests/test_core/test_health_security.py
+++ b/tests/test_core/test_health_security.py
@@ -21,7 +21,7 @@ def health_app(monkeypatch):
     monkeypatch.setattr(settings, "OPERATIONAL_PUBLIC", False)
     monkeypatch.setattr(settings, "OPERATIONAL_TRUSTED_IPS", ["10.0.0.0/8"])
     monkeypatch.setattr(settings, "API_RATE_LIMIT_ENFORCE", True)
-    monkeypatch.setattr(settings, "HEALTH_RATE_LIMIT_PER_MINUTE", 3)
+    monkeypatch.setattr(settings, "HEALTH_RATE_LIMIT_PER_MINUTE", 120)
     monkeypatch.setattr(settings, "HEALTH_READINESS_CACHE_SECONDS", 0)
 
     def _is_trusted_probe(request: Request) -> bool:
@@ -31,6 +31,7 @@ def health_app(monkeypatch):
         "app.core.operational_access_middleware.is_operational_access_allowed",
         _is_trusted_probe,
     )
+    monkeypatch.setattr("app.core.api_rate_limit.is_operational_access_allowed", _is_trusted_probe)
 
     app = FastAPI()
     app.add_middleware(MigrationCheckMiddleware)
@@ -38,20 +39,24 @@ def health_app(monkeypatch):
 
     @app.get("/health")
     def health(request: Request):
+        check_health_rate_limit(request)
+        payload, status_code = build_liveness_status()
+        return JSONResponse(content=payload, status_code=status_code)
+
+    @app.get("/health/ready")
+    def health_ready(request: Request):
         from app.core.operational_access_middleware import is_operational_access_allowed
 
-        check_health_rate_limit(request)
-        if is_operational_access_allowed(request):
-            payload, status_code = build_readiness_status(detailed=False)
-        else:
-            payload, status_code = build_liveness_status()
+        if not is_operational_access_allowed(request):
+            return JSONResponse(status_code=404, content={"detail": "Not found"})
+        payload, status_code = build_readiness_status(detailed=False)
         return JSONResponse(content=payload, status_code=status_code)
 
     with TestClient(app) as client:
         yield client
 
 
-def test_public_health_is_liveness_only_when_migrations_pending(monkeypatch, health_app):
+def test_public_health_is_liveness_when_migrations_pending(monkeypatch, health_app):
     monkeypatch.setattr(
         "app.core.health.check_migrations_status",
         lambda: (False, ["099_pending.sql"]),
@@ -63,19 +68,26 @@ def test_public_health_is_liveness_only_when_migrations_pending(monkeypatch, hea
     assert response.json() == {"status": "ok"}
 
 
-def test_trusted_lb_peer_gets_readiness_when_migrations_pending(monkeypatch, health_app):
+def test_trusted_lb_peer_gets_readiness_on_health_ready(monkeypatch, health_app):
     monkeypatch.setattr(
         "app.core.health.check_migrations_status",
         lambda: (False, ["099_pending.sql"]),
     )
 
-    response = health_app.get("/health", headers={"x-test-trusted-probe": "1"})
+    response = health_app.get("/health/ready", headers={"x-test-trusted-probe": "1"})
 
     assert response.status_code == 503
     assert response.json() == {"status": "degraded"}
 
 
+def test_public_health_ready_is_hidden(monkeypatch, health_app):
+    response = health_app.get("/health/ready", headers={"X-Forwarded-For": "203.0.113.1"})
+
+    assert response.status_code == 404
+
+
 def test_public_health_rate_limited(monkeypatch, health_app):
+    monkeypatch.setattr(settings, "HEALTH_RATE_LIMIT_PER_MINUTE", 3)
     monkeypatch.setattr(
         "app.core.health.check_migrations_status",
         lambda: (True, []),

--- a/tests/test_core/test_migrations_sharding.py
+++ b/tests/test_core/test_migrations_sharding.py
@@ -1,0 +1,185 @@
+"""Tests for sharded migration scope, gap recovery, and catalog schema verification."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+
+from app.core.migrations import (
+    MigrationRunner,
+    _catalog_migration_gaps,
+    _is_catalog_engine_url,
+    _migration_applies_to_engine,
+    verify_catalog_schema,
+)
+from app.core.migrations import MIGRATIONS_DIR
+
+
+@pytest.fixture
+def catalog_db():
+    engine = create_engine("sqlite:///:memory:")
+    factory = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    db = factory()
+    db.execute(
+        text(
+            """
+            CREATE TABLE users (
+                id TEXT PRIMARY KEY,
+                email TEXT NOT NULL
+            )
+            """
+        )
+    )
+    db.commit()
+    try:
+        yield db
+    finally:
+        db.close()
+        engine.dispose()
+
+
+def test_migration_applies_catalog_only_on_catalog_engine():
+    catalog_migration = MIGRATIONS_DIR / "086_user_session_epoch.py"
+    all_migration = MIGRATIONS_DIR / "088_refresh_token_authenticated_org_ids.py"
+
+    assert _migration_applies_to_engine(
+        catalog_migration,
+        is_catalog=True,
+        sharding_enabled=True,
+    )
+    assert not _migration_applies_to_engine(
+        catalog_migration,
+        is_catalog=False,
+        sharding_enabled=True,
+    )
+    assert _migration_applies_to_engine(
+        all_migration,
+        is_catalog=False,
+        sharding_enabled=True,
+    )
+
+
+def test_migration_applies_everything_when_sharding_disabled():
+    catalog_migration = MIGRATIONS_DIR / "086_user_session_epoch.py"
+    assert _migration_applies_to_engine(
+        catalog_migration,
+        is_catalog=False,
+        sharding_enabled=False,
+    )
+
+
+def test_catalog_migration_gaps_detect_missing_prerequisites():
+    applied = {
+        "088_refresh_token_authenticated_org_ids",
+        "089_refresh_token_authenticated_org_epochs",
+        "090_organization_member_session_revocations",
+    }
+    gaps = _catalog_migration_gaps(applied)
+    gap_versions = {path.stem for path in gaps}
+    assert "086_user_session_epoch" in gap_versions
+    assert "087_organization_member_credentials" in gap_versions
+
+
+def test_catalog_migration_gaps_empty_when_prerequisites_applied():
+    applied = {
+        "086_user_session_epoch",
+        "087_organization_member_credentials",
+        "088_refresh_token_authenticated_org_ids",
+    }
+    gaps = _catalog_migration_gaps(applied)
+    assert gaps == []
+
+
+def test_pending_includes_catalog_gaps(catalog_db):
+    catalog_db.execute(
+        text(
+            """
+            CREATE TABLE schema_migrations (
+                version VARCHAR(255) PRIMARY KEY,
+                applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                description TEXT
+            )
+            """
+        )
+    )
+    for version in (
+        "088_refresh_token_authenticated_org_ids",
+        "089_refresh_token_authenticated_org_epochs",
+        "090_organization_member_session_revocations",
+    ):
+        catalog_db.execute(
+            text("INSERT INTO schema_migrations (version, description) VALUES (:version, :description)"),
+            {"version": version, "description": version},
+        )
+    catalog_db.commit()
+
+    runner = MigrationRunner(catalog_db, is_catalog=True, sharding_enabled=True)
+    pending_versions = {path.stem for path in runner.get_pending_migrations()}
+    assert "086_user_session_epoch" in pending_versions
+    assert "087_organization_member_credentials" in pending_versions
+    assert "091_catalog_security_schema_repair" in pending_versions
+
+
+def test_verify_catalog_schema_reports_missing_session_epoch(catalog_db):
+    errors = verify_catalog_schema(catalog_db)
+    assert "users.session_epoch column missing" in errors
+
+
+def test_verify_catalog_schema_passes_with_session_epoch(catalog_db):
+    catalog_db.execute(
+        text("ALTER TABLE users ADD COLUMN session_epoch INTEGER NOT NULL DEFAULT 0")
+    )
+    catalog_db.execute(
+        text(
+            """
+            CREATE TABLE organization_member_credentials (
+                id TEXT PRIMARY KEY,
+                organization_id TEXT NOT NULL,
+                user_id TEXT NOT NULL
+            )
+            """
+        )
+    )
+    catalog_db.commit()
+    assert verify_catalog_schema(catalog_db) == []
+
+
+def test_is_catalog_engine_url_ignores_masked_password(monkeypatch):
+    from sqlalchemy.engine import make_url
+
+    catalog_url = "postgresql://efficientai:password@localhost:5432/efficientai"
+    monkeypatch.setattr(
+        "app.config.settings",
+        type(
+            "S",
+            (),
+            {
+                "DB_SHARDING_ENABLED": True,
+                "DB_CATALOG_URL": catalog_url,
+                "DATABASE_URL": catalog_url,
+            },
+        )(),
+    )
+    engine_url = make_url(catalog_url)
+    assert _is_catalog_engine_url(engine_url)
+
+
+def test_is_catalog_engine_url_matches_catalog_host(monkeypatch):
+    catalog_url = "postgresql://user:pass@catalog-host:5432/efficientai?sslmode=require"
+    monkeypatch.setattr(
+        "app.config.settings",
+        type(
+            "S",
+            (),
+            {
+                "DB_SHARDING_ENABLED": True,
+                "DB_CATALOG_URL": catalog_url,
+                "DATABASE_URL": "postgresql://user:pass@shard-host:5432/efficientai_data_01",
+            },
+        )(),
+    )
+    assert _is_catalog_engine_url(catalog_url)
+    assert not _is_catalog_engine_url(
+        "postgresql://user:pass@shard-host:5432/efficientai_data_01?sslmode=require"
+    )

--- a/tests/test_core/test_oidc_config.py
+++ b/tests/test_core/test_oidc_config.py
@@ -76,6 +76,13 @@ def test_validate_auth_configuration_requires_audience_for_external_oidc(monkeyp
         validate_auth_configuration()
 
 
+def test_validate_auth_configuration_rejects_weak_secret_when_not_debug(monkeypatch):
+    monkeypatch.setattr(settings, "DEBUG", False)
+    monkeypatch.setattr(settings, "SECRET_KEY", "your-secret-key-here-change-in-production")
+    with pytest.raises(RuntimeError, match="SECRET_KEY"):
+        validate_auth_configuration()
+
+
 def test_verify_jwt_rejects_missing_audience(monkeypatch):
     reset_jwks_cache()
     with pytest.raises(AuthError, match="OIDC audience is not configured"):

--- a/tests/test_core/test_operational_endpoints.py
+++ b/tests/test_core/test_operational_endpoints.py
@@ -187,6 +187,12 @@ def test_docs_not_registered_when_debug_disabled(monkeypatch):
     from app.main import create_app
 
     monkeypatch.setattr(settings, "DEBUG", False)
+    monkeypatch.setattr(settings, "SECRET_KEY", "test-operational-secret-key-32chars")
+    monkeypatch.setattr(
+        settings,
+        "TRUSTED_HOSTS",
+        ["testserver", "localhost", "127.0.0.1"],
+    )
     app = create_app()
     route_paths = {getattr(route, "path", None) for route in app.routes}
 
@@ -214,18 +220,6 @@ def _stub_create_app_startup(monkeypatch) -> None:
     monkeypatch.setattr("app.app_factory.init_db", lambda: None)
 
 
-    monkeypatch.setattr(
-        "app.core.health.check_migrations_status",
-        lambda: (False, ["033_add_workspaces.sql"]),
-    )
-
-    payload, status_code = build_health_status(detailed=True)
-
-    assert status_code == 503
-    assert payload["status"] == "degraded"
-    assert payload["pending_migrations"] == ["033_add_workspaces.sql"]
-
-
 def test_health_detail_returns_migration_info_for_admin(monkeypatch):
     _stub_create_app_startup(monkeypatch)
     monkeypatch.setitem(
@@ -235,16 +229,26 @@ def test_health_detail_returns_migration_info_for_admin(monkeypatch):
     )
     monkeypatch.setattr(settings, "OPERATIONAL_PUBLIC", True)
     monkeypatch.setattr(settings, "DEBUG", False)
+    monkeypatch.setattr(settings, "SECRET_KEY", "test-operational-secret-key-32chars")
     monkeypatch.setattr(settings, "FRONTEND_DIR", "__missing_frontend__")
     monkeypatch.setattr(settings, "OBSERVABILITY_ENABLED", False)
     monkeypatch.setattr(
         "app.core.health.check_migrations_status",
         lambda: (True, []),
     )
+    monkeypatch.setattr(
+        "app.services.observability.catalog_storage_stats.collect_catalog_storage_stats",
+        lambda _db: {"tables": {}},
+    )
 
     from app.core.auth.rbac import require_admin
     from app.main import create_app
 
+    monkeypatch.setattr(
+        settings,
+        "TRUSTED_HOSTS",
+        ["testserver", "localhost", "127.0.0.1"],
+    )
     app = create_app()
     app.dependency_overrides[require_admin] = lambda: object()
 
@@ -264,11 +268,17 @@ def test_health_detail_requires_authentication_via_create_app(monkeypatch):
     )
     monkeypatch.setattr(settings, "OPERATIONAL_PUBLIC", True)
     monkeypatch.setattr(settings, "DEBUG", False)
+    monkeypatch.setattr(settings, "SECRET_KEY", "test-operational-secret-key-32chars")
     monkeypatch.setattr(settings, "FRONTEND_DIR", "__missing_frontend__")
     monkeypatch.setattr(settings, "OBSERVABILITY_ENABLED", False)
 
     from app.main import create_app
 
+    monkeypatch.setattr(
+        settings,
+        "TRUSTED_HOSTS",
+        ["testserver", "localhost", "127.0.0.1"],
+    )
     with TestClient(create_app()) as client:
         response = client.get("/health/detail")
 

--- a/tests/test_core/test_operational_endpoints.py
+++ b/tests/test_core/test_operational_endpoints.py
@@ -222,6 +222,7 @@ def _stub_create_app_startup(monkeypatch) -> None:
     """Tests use create_all(); avoid re-running file migrations on TestClient startup."""
     monkeypatch.setattr("app.app_factory.run_migrations", lambda: None)
     monkeypatch.setattr("app.app_factory.init_db", lambda: None)
+    monkeypatch.setattr("app.app_factory.check_migrations_status", lambda: (True, []))
 
 
 def test_health_detail_returns_migration_info_for_admin(monkeypatch):

--- a/tests/test_core/test_operational_endpoints.py
+++ b/tests/test_core/test_operational_endpoints.py
@@ -12,7 +12,7 @@ from fastapi.testclient import TestClient
 from starlette.requests import Request
 
 from app.config import settings
-from app.core.health import build_health_status
+from app.core.health import build_liveness_status
 from app.core.migration_middleware import MigrationCheckMiddleware
 from app.core.operational_access_middleware import (
     OperationalAccessMiddleware,
@@ -55,7 +55,7 @@ def operational_client(monkeypatch):
 
     @app.get("/health")
     def health():
-        payload, status_code = build_health_status(detailed=False)
+        payload, status_code = build_liveness_status()
         return JSONResponse(content=payload, status_code=status_code)
 
     @app.get("/metrics")

--- a/tests/test_core/test_operational_endpoints.py
+++ b/tests/test_core/test_operational_endpoints.py
@@ -201,13 +201,17 @@ def test_docs_not_registered_when_debug_disabled(monkeypatch):
     assert "/openapi.json" not in route_paths
 
 
-def test_build_health_status_minimal_excludes_migration_details(monkeypatch):
+def test_build_readiness_status_minimal_excludes_migration_details(monkeypatch):
+    import app.core.health as health_module
+
+    monkeypatch.setattr(settings, "HEALTH_READINESS_CACHE_SECONDS", 0)
+    health_module._readiness_cached_at = 0.0
     monkeypatch.setattr(
         "app.core.health.check_migrations_status",
         lambda: (False, ["033_add_workspaces.sql"]),
     )
 
-    payload, status_code = build_health_status(detailed=False)
+    payload, status_code = health_module.build_readiness_status(detailed=False)
 
     assert status_code == 503
     assert payload == {"status": "degraded"}
@@ -232,6 +236,11 @@ def test_health_detail_returns_migration_info_for_admin(monkeypatch):
     monkeypatch.setattr(settings, "SECRET_KEY", "test-operational-secret-key-32chars")
     monkeypatch.setattr(settings, "FRONTEND_DIR", "__missing_frontend__")
     monkeypatch.setattr(settings, "OBSERVABILITY_ENABLED", False)
+    import app.core.health as health_module
+
+    monkeypatch.setattr(settings, "HEALTH_READINESS_CACHE_SECONDS", 0)
+    health_module._readiness_cached_at = 0.0
+    health_module._readiness_cached_status = (True, [])
     monkeypatch.setattr(
         "app.core.health.check_migrations_status",
         lambda: (True, []),

--- a/tests/test_core/test_security_headers_middleware.py
+++ b/tests/test_core/test_security_headers_middleware.py
@@ -119,6 +119,19 @@ def test_asset_routes_use_long_cache(security_client):
     assert "Pragma" not in response.headers
 
 
+def test_hsts_header_when_enabled(security_client, monkeypatch):
+    monkeypatch.setattr(settings, "SECURITY_HSTS_ENABLED", True)
+    monkeypatch.setattr(settings, "SECURITY_HSTS_MAX_AGE", 31536000)
+    monkeypatch.setattr(settings, "SECURITY_HSTS_INCLUDE_SUBDOMAINS", True)
+
+    response = security_client.get("/health")
+
+    assert response.status_code == 200
+    assert response.headers["Strict-Transport-Security"] == (
+        "max-age=31536000; includeSubDomains"
+    )
+
+
 @pytest.mark.skipif(
     not (Path(settings.FRONTEND_DIR) / "assets").is_dir(),
     reason="frontend dist assets not built in test environment",

--- a/tests/test_core/test_trusted_host_middleware.py
+++ b/tests/test_core/test_trusted_host_middleware.py
@@ -1,0 +1,69 @@
+"""Tests for selective Host header validation."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.config import settings
+from app.core.trusted_host_middleware import SelectiveTrustedHostMiddleware
+
+
+@pytest.fixture
+def host_client(monkeypatch):
+    monkeypatch.setattr(settings, "TRUSTED_HOSTS", ["sandbox.efficientai.cloud"])
+    monkeypatch.setattr(settings, "OPERATIONAL_TRUSTED_IPS", ["10.0.0.0/8"])
+
+    app = FastAPI()
+    app.add_middleware(SelectiveTrustedHostMiddleware, allowed_hosts=settings.TRUSTED_HOSTS)
+
+    @app.get("/health")
+    def health():
+        return {"status": "healthy"}
+
+    @app.get("/api/v1/ping")
+    def ping():
+        return {"ok": True}
+
+    with TestClient(app) as client:
+        yield client
+
+
+def test_health_allows_internal_ip_host_header(host_client):
+    response = host_client.get("/health", headers={"Host": "10.20.2.137"})
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "healthy"}
+
+
+def test_health_allows_public_domain_host_header(host_client):
+    response = host_client.get("/health", headers={"Host": "sandbox.efficientai.cloud"})
+
+    assert response.status_code == 200
+
+
+def test_api_allows_configured_public_host(host_client):
+    response = host_client.get("/api/v1/ping", headers={"Host": "sandbox.efficientai.cloud"})
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+
+
+def test_api_allows_host_ip_in_operational_trusted_ips(host_client):
+    response = host_client.get("/api/v1/ping", headers={"Host": "10.20.2.137"})
+
+    assert response.status_code == 200
+
+
+def test_api_rejects_untrusted_host(host_client):
+    response = host_client.get("/api/v1/ping", headers={"Host": "evil.example.com"})
+
+    assert response.status_code == 400
+    assert response.text == "Invalid host header"
+
+
+def test_api_rejects_missing_host_header(host_client):
+    response = host_client.get("/api/v1/ping", headers={"Host": ""})
+
+    assert response.status_code == 400

--- a/tests/test_security_remediation.py
+++ b/tests/test_security_remediation.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 import pytest
 from fastapi import HTTPException
 
+from app.config import settings
 from app.core.api_rate_limit import check_auth_rate_limit, check_resource_create_rate_limit
 from app.core.auth.principal import AuthMethod, Principal
 from app.core.auth.session_epoch import bump_user_session_epoch
@@ -76,7 +77,8 @@ def test_bump_user_session_epoch_increments():
     assert user.session_epoch == 2
 
 
-def test_check_auth_rate_limit_allows_under_threshold():
+def test_check_auth_rate_limit_allows_under_threshold(monkeypatch):
+    monkeypatch.setattr(settings, "API_RATE_LIMIT_ENFORCE", True)
     request = MagicMock()
     request.headers = {}
     request.client = MagicMock(host="127.0.0.1")
@@ -84,7 +86,8 @@ def test_check_auth_rate_limit_allows_under_threshold():
         check_auth_rate_limit(request)
 
 
-def test_check_resource_create_rate_limit_blocks_burst():
+def test_check_resource_create_rate_limit_blocks_burst(monkeypatch):
+    monkeypatch.setattr(settings, "API_RATE_LIMIT_ENFORCE", True)
     principal = Principal(
         organization_id=uuid4(),
         auth_method=AuthMethod.LOCAL_PASSWORD,

--- a/tests/test_security_remediation.py
+++ b/tests/test_security_remediation.py
@@ -1,0 +1,97 @@
+"""Security remediation tests (Astra pentest fixes)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from app.core.api_rate_limit import check_auth_rate_limit, check_resource_create_rate_limit
+from app.core.auth.principal import AuthMethod, Principal
+from app.core.auth.session_epoch import bump_user_session_epoch
+from app.core.auth.tokens import create_access_token, decode_access_token
+from app.services.ai.llm_config_safety import sanitize_client_llm_config
+from app.services.telephony.exotel_client import ExotelInvalidContentError
+from app.services.telephony.recording_download import (
+    assert_outbound_http_url_safe,
+    assert_recording_url_safe,
+    assert_safe_provider_recording_url,
+)
+
+
+def test_user_update_forbids_email_field():
+    from pydantic import ValidationError
+
+    from app.models.schemas import UserUpdate
+
+    with pytest.raises(ValidationError):
+        UserUpdate(email="hacker@evil.com")
+
+
+def test_sanitize_client_llm_config_strips_dangerous_keys():
+    raw = {
+        "temperature": 0.2,
+        "api_base": "https://evil.example/v1",
+        "api_key": "secret",
+        "max_tokens": 100,
+    }
+    sanitized = sanitize_client_llm_config(raw)
+    assert sanitized == {"temperature": 0.2, "max_tokens": 100}
+
+
+def test_assert_safe_provider_recording_url_blocks_metadata_ip():
+    with pytest.raises(ExotelInvalidContentError):
+        assert_safe_provider_recording_url("http://169.254.169.254/latest/meta-data/")
+
+
+def test_assert_recording_url_safe_blocks_metadata_ip():
+    with pytest.raises(ExotelInvalidContentError):
+        assert_recording_url_safe("http://169.254.169.254/latest/meta-data/", user_supplied=True)
+
+
+def test_assert_outbound_http_url_safe_blocks_metadata_ip():
+    with pytest.raises(ExotelInvalidContentError):
+        assert_outbound_http_url_safe("http://169.254.169.254/")
+
+
+def test_session_epoch_in_access_token():
+    user_id = uuid4()
+    org_id = uuid4()
+    token, _, _ = create_access_token(
+        user_id=user_id,
+        organization_id=org_id,
+        email="user@example.com",
+        session_epoch=3,
+    )
+    claims = decode_access_token(token)
+    assert claims["session_epoch"] == 3
+
+
+def test_bump_user_session_epoch_increments():
+    user = MagicMock()
+    user.session_epoch = 1
+    assert bump_user_session_epoch(user) == 2
+    assert user.session_epoch == 2
+
+
+def test_check_auth_rate_limit_allows_under_threshold():
+    request = MagicMock()
+    request.headers = {}
+    request.client = MagicMock(host="127.0.0.1")
+    with patch("app.core.api_rate_limit._sliding_window_count", return_value=1):
+        check_auth_rate_limit(request)
+
+
+def test_check_resource_create_rate_limit_blocks_burst():
+    principal = Principal(
+        organization_id=uuid4(),
+        auth_method=AuthMethod.LOCAL_PASSWORD,
+        user_id=uuid4(),
+        email="u@example.com",
+    )
+    with patch("app.core.api_rate_limit._sliding_window_count", return_value=999):
+        with pytest.raises(HTTPException) as exc:
+            check_resource_create_rate_limit(principal)
+        assert exc.value.status_code == 429

--- a/tests/test_services/test_call_imports/test_progress_counters.py
+++ b/tests/test_services/test_call_imports/test_progress_counters.py
@@ -51,7 +51,9 @@ def test_flush_eval_restores_redis_when_catalog_flush_fails():
 
 
 def test_engine_role_uses_parsed_url_comparison():
-    from app.core.migrations import _engine_role_for_url
+    from sqlalchemy.engine import make_url
+
+    from app.core.migrations import _is_catalog_engine_url
 
     catalog = "postgresql://user:pass@localhost:5432/efficientai_catalog"
     normalized = "postgresql+psycopg2://user:pass@localhost:5432/efficientai_catalog"
@@ -62,7 +64,7 @@ def test_engine_role_uses_parsed_url_comparison():
         DATABASE_URL = catalog
 
     with patch("app.config.settings", _Settings()):
-        assert _engine_role_for_url(normalized) == "catalog"
-        assert _engine_role_for_url(
+        assert _is_catalog_engine_url(make_url(normalized))
+        assert not _is_catalog_engine_url(
             "postgresql://user:pass@localhost:5432/efficientai_data_01"
-        ) == "shard"
+        )

--- a/tests/test_services/test_media_urls.py
+++ b/tests/test_services/test_media_urls.py
@@ -1,7 +1,33 @@
 """Tests for media / telephony URL helpers."""
 
+from starlette.requests import Request
+
 from app.config import settings
+from app.services.media_urls import cross_host_voice_ws, resolve_voice_agent_ws_base
 from app.services.telephony.vobiz_agent_context import build_carrier_ws_url
+
+
+def test_cross_host_voice_ws_detects_different_hostname():
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/api/v1/voice-agent/connect",
+        "headers": [(b"host", b"api.example.com")],
+        "query_string": b"",
+        "server": ("api.example.com", 443),
+        "client": ("127.0.0.1", 12345),
+        "scheme": "https",
+        "root_path": "",
+    }
+    request = Request(scope)
+
+    assert cross_host_voice_ws("wss://media.example.com", request) is True
+    assert cross_host_voice_ws("wss://api.example.com", request) is False
+
+
+def test_resolve_voice_agent_ws_base_prefers_media_ws(monkeypatch):
+    monkeypatch.setattr(settings, "MEDIA_WS_BASE_URL", "wss://media.example.com")
+    assert resolve_voice_agent_ws_base() == "wss://media.example.com"
 
 
 def test_build_carrier_ws_url_uses_webhook_base_when_media_ws_unset(monkeypatch):

--- a/tests/test_services/test_telephony/test_recording_download.py
+++ b/tests/test_services/test_telephony/test_recording_download.py
@@ -50,7 +50,7 @@ def test_assert_recording_url_safe_rejects_non_allowlisted_host(monkeypatch):
     monkeypatch.setattr(
         module.settings,
         "RECORDING_URL_ALLOWED_HOST_SUFFIXES",
-        ["exotel.com"],
+        [],
         raising=False,
     )
     with pytest.raises(ExotelInvalidContentError, match="not allowlisted"):
@@ -58,6 +58,32 @@ def test_assert_recording_url_safe_rejects_non_allowlisted_host(monkeypatch):
             "https://evil.example/recording.mp3",
             user_supplied=True,
         )
+
+
+def test_assert_recording_url_safe_allows_cloudflare_r2(monkeypatch):
+    monkeypatch.setattr(
+        module.settings,
+        "RECORDING_URL_ALLOWED_HOST_SUFFIXES",
+        [],
+        raising=False,
+    )
+    with patch.object(module.socket, "getaddrinfo") as mock_getaddrinfo:
+        mock_getaddrinfo.return_value = [(None, None, None, None, ("104.16.0.1", 0))]
+        module.assert_safe_provider_recording_url(
+            "https://hipaa-recordings.94bdb67bb98da30b06bdd917725c037d.r2.cloudflarestorage.com/rec.wav"
+        )
+
+
+def test_allowed_host_suffixes_merges_configured_extras(monkeypatch):
+    monkeypatch.setattr(
+        module.settings,
+        "RECORDING_URL_ALLOWED_HOST_SUFFIXES",
+        ["recordings.mycompany.com"],
+        raising=False,
+    )
+    suffixes = module._allowed_host_suffixes()
+    assert "r2.cloudflarestorage.com" in suffixes
+    assert "recordings.mycompany.com" in suffixes
 
 
 def test_download_recording_url_rejects_credentials_for_user_supplied_urls():

--- a/tests/test_services/test_voice_agent/test_audio_recorder.py
+++ b/tests/test_services/test_voice_agent/test_audio_recorder.py
@@ -295,13 +295,15 @@ def test_playout_mode_does_not_compress_burst_audio(tmp_path):
     """
 
     async def run():
-        start = time.time()
         recorder, path = _make_recorder(
-            tmp_path, capture="output", alignment_mode="playout", start_time=start
+            tmp_path, capture="output", alignment_mode="playout", start_time=time.time()
         )
         recorder.push_frame = AsyncMock()
 
         await recorder.process_frame(BotStartedSpeakingFrame(), FrameDirection.DOWNSTREAM)
+        # Align the call timeline to utterance start so this test only checks that
+        # burst audio is not compressed, not variable pre-utterance wall-clock pad.
+        recorder.start_time = recorder._pending_anchor_time or time.time()
         # 1s of audio (8000 samples) delivered in one burst, i.e. no wall-clock time.
         for _ in range(10):
             await recorder.process_frame(

--- a/tests/test_workers/test_beat_schedule.py
+++ b/tests/test_workers/test_beat_schedule.py
@@ -21,7 +21,8 @@ def test_usage_flush_beat_seconds_clamps_minimum(monkeypatch):
     assert _usage_flush_beat_seconds() == 30.0
 
 
-def test_cron_dispatch_beat_seconds_defaults_to_30():
+def test_cron_dispatch_beat_seconds_defaults_to_30(monkeypatch):
+    monkeypatch.delenv("CRON_DISPATCH_INTERVAL_SECONDS", raising=False)
     assert _cron_dispatch_beat_seconds() == 30.0
 
 


### PR DESCRIPTION
## What Changed?

Security remediation from the  audit, cherry-picked onto `main` (replaces the old `security-patches` branch):

- **Auth:** httpOnly cookie sessions (`eai_access` / `eai_refresh` / `eai_csrf`), CSRF middleware, session epoch invalidation on password change, strong `SECRET_KEY` enforcement when `debug: false`
- **API hardening:** SSRF checks on recording/audio URLs, reader RBAC query-token bypass fix, abuse-only rate limits on auth/resource creates, LLM config sanitization
- **Headers:** TrustedHost + HSTS support
- **Frontend:** Cookie-session bootstrap, silent refresh, CSRF on axios + Pipecat voice-agent connect, profile/password UX fixes
- **Fixes:** Duplicate invite → 409, wrong password → 400, expanded recording URL allowlist (incl. R2), App.tsx route cleanup

## Why?

The audit flagged token exposure in `localStorage`, missing CSRF protection, SSRF via recording URLs, weak session invalidation, and several auth/RBAC gaps. Cookie-based sessions with double-submit CSRF address browser auth without storing tokens in JS-accessible storage, while SSRF allowlists and outbound URL validation block server-side fetch abuse. Cherry-picking onto `main` keeps the PR focused (~6 commits) instead of the prior branch that included unrelated otel work.

## How to Test?

1. **Migrate:** `eai migrate` (confirms `086_user_session_epoch`)
2. **Config:** ensure `auth.local_password.cookie_session.enabled: true` and `security.trusted_hosts` includes `localhost`
3. **Login:** sign in → DevTools cookies show `eai_access`, `eai_refresh`, `eai_csrf` → refresh page stays logged in
4. **Voice call:** Agent Playground → start test call → should connect (no CSRF 403)
5. **Password:** Profile → wrong current password → error toast, **not** logged out; correct change → redirected to login
6. **Invite:** IAM → invite same email twice → toast: *"An invitation is already pending for this email"*
7. **Recording:** play audio on a call with R2/Cloudflare URL → no allowlist error
8. **Tests:**
   ```bash
   .venv/bin/pytest tests/test_core/test_auth_cookies.py \
     tests/test_security_remediation.py tests/test_api/test_security_rbac.py \
     tests/test_services/test_telephony/test_recording_download.py -v
   cd frontend && npm run build
   ```

**Deploy note:** production needs `debug: false`, strong `secret_key`, `cookie_session.secure: true`, `trusted_hosts`, and `hsts_enabled: true`.

## Release Label

- [ ] `major`
- [ ] `minor`
- [x] `fix` — backward-compatible security hardening and bug fixes; patch release
- [ ] No label

## Checklist

- [ x] I have read the `CONTRIBUTING.md` guide.
- [x] My code follows the project's style guidelines.
- [x] I have added tests that prove my fix is effective or my feature works.
- [ x] I have updated documentation where needed. *(TDD on Confluence exists; `config.yml.example` / `env.example` updated in-repo)*